### PR TITLE
If corresponding env var exists, use it in config.sh

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
 # Cofigurations for tmux-powerline.
 
-# You platform \in {linux,bsd,mac}.
-export PLATFORM="linux"
+if [ -z "$PLATFORM" ]; then
+    # You platform \in {linux,bsd,mac}.
+    export PLATFORM="linux"
+fi
 
-# Useage of patched font for symbols. true or false.
-export USE_PATCHED_FONT="true"
+if [ -z "$USE_PATCHED_FONT" ]; then
+    # Useage of patched font for symbols. true or false.
+    export USE_PATCHED_FONT="true"
+fi


### PR DESCRIPTION
This pull request let user specify PROMPT and USE_PATCHED_FONT in his `.bashrc`.
## Why I need this?

I want to use tmux-powerline as submodule of my [dotfiles repository](https://github.com/taka84u9/dotfiles).
Since `status-(left|right).sh` use some environment variables defined in `config.sh`, user have to edit the file directly. This means that I have to modify the submodule, but, as you know, this kind of modification sometimes makes me hard to follow the origin repository.
