### PR TITLE
If corresponding env var exists, use it in config.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ set-option -g status-left "#(~/path/to/tmux-powerline/status-left.sh)"
 set-option -g status-right "#(~/path/to/tmux-powerline/status-right.sh)"
 ```
 
-Set the maximum lengths to something that suits your configuration of segments and size of terminal (the maximum segments length will be handled better in the future). Don't forget to change the PLATFORM variable in `config.sh` to reflect your operating system of choice.
+Set the maximum lengths to something that suits your configuration of segments and size of terminal (the maximum segments length will be handled better in the future). Don't forget to change the PLATFORM variable in `config.sh` or your `~/.bashrc` to reflect your operating system of choice.
 
 Also I recommend you to use the [tmux-colors-solarized](https://github.com/seebi/tmux-colors-solarized) theme (as well as solarized for [everything else](http://ethanschoonover.com/solarized) :)):
 

--- a/config.sh
+++ b/config.sh
@@ -1,8 +1,12 @@
 #!/bin/sh
 # Cofigurations for tmux-powerline.
 
-# You platform \in {linux,bsd,mac}.
-export PLATFORM="linux"
+if [ -z "$PLATFORM" ]; then
+	# You platform \in {linux,bsd,mac}.
+	export PLATFORM="linux"
+fi
 
-# Useage of patched font for symbols. true or false.
-export USE_PATCHED_FONT="true"
+if [ -z "$USE_PATCHED_FONT" ]; then
+	# Useage of patched font for symbols. true or false.
+	export USE_PATCHED_FONT="true"
+fi


### PR DESCRIPTION
This pull request let user specify PROMPT and USE_PATCHED_FONT in his `.bashrc`.

Differences from #22 are
- tab is used for indenting.
- README.md is changed
## Why I need this?

I want to use tmux-powerline as submodule of my [dotfiles repository](https://github.com/taka84u9/dotfiles).
Since `status-(left|right).sh` use some environment variables defined in `config.sh`, user have to edit the file directly. This means that I have to modify the submodule, but, as you know, this kind of modification sometimes makes me hard to follow the origin repository.
