### PR TITLE
add GREP_OPTIONS to avoid grep coloring

### DIFF
--- a/lib.sh
+++ b/lib.sh
@@ -17,6 +17,8 @@ else
 	separator_right_thin="❯"
 fi
 
+export GREP_OPTIONS="--color=never"
+
 # Register a segment.
 register_segment() {
 	segment_name="$1"


### PR DESCRIPTION
hi,
According to this pull request
https://github.com/erikw/tmux-powerline/pull/26
I added `GREP_OPTIONS="--color=never"` in lib.sh.

please take a look.
