### PR TITLE
Current_condition is now properly checked on OS X (PCRE Grep not supported on OS X)

### DIFF
--- a/segments/weather.sh
+++ b/segments/weather.sh
@@ -103,7 +103,7 @@ if [ -z "$degrees" ]; then
 		fi
 		degrees=$(echo "$weather_data" | sed "s|.*<temp_${search_unit} data=\"\([^\"]*\)\"/>.*|\1|")
 		if [ "$PLATFORM" == "mac" ]; then
-			conditions=$(echo "$weather_data" | grep -EZo "<current_conditions>(\\n|.)*</current_conditions>" | grep -EZo '<condition data="([a-zA-Z]*)"/>' | sed -n 's/^.*\"\([a-zA-Z]*\)\".*/\1/p')
+			conditions=$(echo "$weather_data" | grep -EZo "<current_conditions>(\\n|.)*</current_conditions>" | grep -EZo '<condition data="([a-zA-Z ]*)"/>' | sed -n 's/^.*\"\([a-zA-Z ]*\)\".*/\1/p')
 		else
 			conditions=$(echo "$weather_data" | grep -PZo "<current_conditions>(\\n|.)*</current_conditions>" | grep -PZo "(?<=<condition\sdata=\")([^\"]*)")
 		fi


### PR DESCRIPTION
On default installs of OS X, grep doesn't support grep -P so I combined grep + sed to get the right result for condition data.
This has been tested on Mountain Lion.
