### PR TITLE
Fix the cpu stats for OS X

### DIFF
--- a/segments/cpu.sh
+++ b/segments/cpu.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env sh
 # Prints the CPU usage: user% sys% idle.
 
-cpu_line=$(top -b -n 1 | grep "Cpu(s)")
-
-cpu_user=$(echo "$cpu_line" | grep -Po "(\d+(.\d+)?)(?=%?\s?(us(er)?))")
-cpu_system=$(echo "$cpu_line" | grep -Po "(\d+(.\d+)?)(?=%?\s?(sys?))")
-cpu_idle=$(echo "$cpu_line" | grep -Po "(\d+(.\d+)?)(?=%?\s?(id(le)?))")
+if [ "$PLATFORM" == "Linux" ] ; then
+    cpu_line=$(top -b -n 1 | grep "Cpu(s)" )
+    cpu_user=$(echo "$cpu_line" | grep -Po "(\d+(.\d+)?)(?=%?\s?(us(er)?))")
+    cpu_system=$(echo "$cpu_line" | grep -Po "(\d+(.\d+)?)(?=%?\s?(sys?))")
+    cpu_idle=$(echo "$cpu_line" | grep -Po "(\d+(.\d+)?)(?=%?\s?(id(le)?))")
+else
+    cpus_line=$(top -l 1 | grep "CPU usage:" | sed 's/CPU usage: //')
+    cpu_user=$(echo "$cpus_line" | awk '{print $1}'  | sed 's/%//' )
+    cpu_system=$(echo "$cpus_line" | awk '{print $3}'| sed 's/%//' )
+    cpu_idle=$(echo "$cpus_line" | awk '{print $5}'  | sed 's/%//' )
+fi
 
 if [ -n "$cpu_user" ] && [ -n "$cpu_system" ] && [ -n "$cpu_idle" ]; then
     echo "${cpu_user}, ${cpu_system}, ${cpu_idle}" | awk -F', ' '{printf("%5.1f,%5.1f,%5.1f",$1,$2,$3)}'


### PR DESCRIPTION
This pull request modifies the cpu.sh segment. 
1. It fixes the script for the "mac" platform
2. It formats the cpu statistics so that it prints out a uniform length string
