### PR TITLE
OSX wrong CPU usage fix

### DIFF
--- a/segments/cpu.sh
+++ b/segments/cpu.sh
@@ -7,7 +7,7 @@ if [ "$PLATFORM" == "linux" ] ; then
     cpu_system=$(echo "$cpu_line" | grep -Po "(\d+(.\d+)?)(?=%?\s?(sys?))")
     cpu_idle=$(echo "$cpu_line" | grep -Po "(\d+(.\d+)?)(?=%?\s?(id(le)?))")
 else
-    cpus_line=$(top -l 1 | grep "CPU usage:" | sed 's/CPU usage: //')
+    cpus_line=$(top -e -l 1 | grep "CPU usage:" | sed 's/CPU usage: //')
     cpu_user=$(echo "$cpus_line" | awk '{print $1}'  | sed 's/%//' )
     cpu_system=$(echo "$cpus_line" | awk '{print $3}'| sed 's/%//' )
     cpu_idle=$(echo "$cpus_line" | awk '{print $5}'  | sed 's/%//' )


### PR DESCRIPTION
(OSX's) top calculates CPU usage since the previous sample in non-event mode(default). But for 1 sample, cpu usage looks higher than it actually is. -e option makes top work in absolute mode(using absolute counters) and users will find cpu usage more precise.
