### PR TITLE
Fix config.sh to automatically select PLATFORM based on 'uname'

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -3,7 +3,11 @@
 
 if [ -z "$PLATFORM" ]; then
 	# You platform \in {linux,bsd,mac}.
-	export PLATFORM="linux"
+    if [[ $(uname) == "Darwin" ]] ; then
+        export PLATFORM="mac"
+    else
+        export PLATFORM="linux"
+    fi
 fi
 
 if [ -z "$USE_PATCHED_FONT" ]; then


### PR DESCRIPTION
This checks if uname returns the valid string for a mac, if not
it assumes the platform is linux.

The previous behavior was to automatically select linux. Here the
only difference is that the system is first checked if it is a mac.

This should simplify adopting tmux-powerline for new users and 
make it less necessary (if not completely unnecessary) for users 
to set $PLATFORM ahead of time.
