### PR TITLE
Add "rain" to list of condition codes

### DIFF
--- a/segments/weather_yahoo.sh
+++ b/segments/weather_yahoo.sh
@@ -29,7 +29,7 @@ get_condition_symbol() {
             echo "☼"
         fi
         ;;
-    "mixed rain and snow" | "mixed rain and sleet" | "freezing drizzle" | "drizzle" | "freezing rain" | "showers" | "mixed rain and hail" | "scattered showers" | "isolated thundershowers" | "thundershowers")
+    "rain" | "mixed rain and snow" | "mixed rain and sleet" | "freezing drizzle" | "drizzle" | "freezing rain" | "showers" | "mixed rain and hail" | "scattered showers" | "isolated thundershowers" | "thundershowers")
             #echo "☂"
             echo "☔"
         ;;


### PR DESCRIPTION
I guess this is the list of possible codes http://developer.yahoo.com/weather/#codes but today I had "Rain"
in as a condition.

&lt;yweather:condition  text="Rain"  code="12"  temp="6"  date="Thu, 01 Nov 2012 3:50 pm CET"/&gt;
