### PR TITLE
Improve performance and simplicity of vcs_compare (git portion)

### DIFF
--- a/segments/vcs_compare.sh
+++ b/segments/vcs_compare.sh
@@ -24,36 +24,15 @@ parse_git_stats(){
     # check if git
     [[ -z $(git rev-parse --git-dir 2> /dev/null) ]] && return
 
-    refs=$(git symbolic-ref HEAD 2> /dev/null)
-    branch=${refs##*/}
-    if [[ -z $branch ]] ; then
-        branch=$(git rev-parse --short HEAD)
-    fi
-
-    # look up this branch in the configuration
-    remote=$(git config branch.$branch.remote)
-    remote_ref=$(git config branch.$branch.merge)
-
-    # if this branch is not connected to a remote
-    [[ -z $remote ]] && return
-
-    # convert the remote ref into the tracking ref... this is a hack
-    remote_branch=$(expr $remote_ref : 'refs/heads/\(.*\)')
-    tracking_branch=refs/remotes/$remote/$remote_branch
-
-    # make a list of behind/ahead left/right sha's
-    tmpLR=/tmp/$(basename $0).left-right
-    git rev-list --left-right $tracking_branch...HEAD &> $tmpLR
-
-    numAhead=$(grep ">" $tmpLR | wc -l)
-    numBehind=$(grep "<" $tmpLR | wc -l)
+    ahead=$( git rev-list origin..HEAD | wc -l)
+    behind=$(git rev-list HEAD..origin | wc -l)
 
     # print out the information
-    if [[ $numBehind -gt 0 ]] ; then
-        local ret="↓ $numBehind"
+    if [[ $behind -gt 0 ]] ; then
+        local ret="↓ $behind"
     fi
-    if [[ $numAhead -gt 0 ]] ; then
-        local ret="${ret}↑ $numAhead"
+    if [[ $ahead -gt 0 ]] ; then
+        local ret="${ret}↑ $ahead"
     fi
     echo $ret
 }


### PR DESCRIPTION
I simplified the vcs_compare git section so that it runs faster and is much easier to understand. Before it was trying to do too much, but the necessary information can be pulled directly out of git in a much simpler way.  
- git is only called twiced compared to 5 times previously (git can be slow)
- No more string manipulation
- No more need to write to a temporary file
- No more reliance on the output of "<" or ">" strings, which could change

Sometimes I think this script slowed down the update of tmux statusbar, which makes it blink on and off occasionally. This should happen less or not at all now.
