### PR TITLE
Improve vcs-compare performance while maintaining compatibility

### DIFF
--- a/segments/vcs_compare.sh
+++ b/segments/vcs_compare.sh
@@ -29,8 +29,8 @@ parse_git_stats(){
     # creates global variables $1 and $2 based on left vs. right tracking
     set -- $(git rev-list --left-right --count $tracking_branch...HEAD)
 
-    ahead=$1
-    behind=$2
+    behind=$1
+    ahead=$2
 
     # print out the information
     if [[ $behind -gt 0 ]] ; then


### PR DESCRIPTION
This version of improved `vcs_compare.sh` should maintain the
functionality of the original script. However, the time required to
execute has been significantly reduced. For my machine using unix `time`
on an early 2011 MacBookPro (15 in. core i7 with 8 GB ram):
1. original (vcs-compare v1.0):
   
   ```
   ./segments/vcs_compare.sh  0.03s user 0.04s system 62% cpu 0.119 total
   ```
2. reduced-functionality for speed (PR #90):
   
   ```
   ./segments/vcs_compare.sh  0.02s user 0.03s system 68% cpu 0.076 total
   ```
3. this commit:
   
   ```
   ./segments/vcs_compare.sh  0.02s user 0.03s system 61% cpu 0.084 total
   ```

As can be seen, this version is not the fastest possible, but it may be
the fastest possible version capable of retaining functionality and
compatability.

Also, note that the times shown are only for a single run, but the times land in middle
of the general trend for each branch in question. No statistical analysis was done ...
who would do that anyway? :P
