### PR TITLE
Add earthquake information segment

### DIFF
--- a/segments/earthquake.sh
+++ b/segments/earthquake.sh
@@ -1,0 +1,173 @@
+# Prints the most recent earthquake (currently only supports japan)
+# It prints the location, time, and magnitude if the quake happened within
+# a timelimit and magnitude threshold
+
+earthquake_symbol='#[fg=colour1]~'
+
+# The update period in seconds.
+update_period=600
+
+TMUX_POWERLINE_SEG_EARTHQUAKE_DATA_PROVIDER_DEFAULT="goo"
+TMUX_POWERLINE_SEG_EARTHQUAKE_UPDATE_PERIOD_DEFAULT="600"
+TMUX_POWERLINE_SEG_EARTHQUAKE_ALERT_TIME_WINDOW_DEFAULT="60"
+TMUX_POWERLINE_SEG_EARTHQUAKE_TIME_FORMAT_DEFAULT='(%H:%M)'
+TMUX_POWERLINE_SEG_EARTHQUAKE_MIN_MAGNITUDE_DEFAULT='3'
+
+generate_segmentrc() {
+	read -d '' rccontents  << EORC
+# The data provider to use. Currently only "goo" is supported.
+export TMUX_POWERLINE_SEG_EARTHQUAKE_DATA_PROVIDER="${TMUX_POWERLINE_SEG_EARTHQUAKE_DATA_PROVIDER_DEFAULT}"
+# How often to update the earthquake data in seconds.
+# Note: This is not an early warning detector, use this
+# to be informed about recent earthquake magnitudes in your
+# area. If this is too often, goo may decide to ban you form
+# their server
+export TMUX_POWERLINE_SEG_EARTHQUAKE_UPDATE_PERIOD="${TMUX_POWERLINE_SEG_EARTHQUAKE_UPDATE_PERIOD_DEFAULT}"
+# Only display information when earthquakes are within this many minutes
+export TMUX_POWERLINE_SEG_EARTHQUAKE_ALERT_TIME_WINDOW="${TMUX_POWERLINE_SEG_EARTHQUAKE_ALERT_TIME_WINDOW_DEFAULT}"
+# Display time with this format
+export TMUX_POWERLINE_SEG_EARTHQUAKE_TIME_FORMAT='${TMUX_POWERLINE_SEG_EARTHQUAKE_TIME_FORMAT_DEFAULT}'
+# Display only if magnitude is greater or equal to this number
+export TMUX_POWERLINE_SEG_EARTHQUAKE_MIN_MAGNITUDE="${TMUX_POWERLINE_SEG_EARTHQUAKE_MIN_MAGNITUDE_DEFAULT}"
+EORC
+	echo "$rccontents"
+}
+
+run_segment() {
+	__process_settings
+	local tmp_file="${TMUX_POWERLINE_DIR_TEMPORARY}/earthquake.txt"
+	local earthquake
+	case "$TMUX_POWERLINE_SEG_EARTHQUAKE_DATA_PROVIDER" in
+		"goo") earthquake=$(__goo_earthquake) ;;
+		*)
+			echo "Unknown earthquake-information provider [${$TMUX_POWERLINE_SEG_EARTHQUAKE_DATA_PROVIDER}]";
+			return 1
+	esac
+	if [ -n "$earthquake" ]; then
+		echo "$earthquake_symbol #[fg=colour237]${earthquake}"
+	fi
+}
+
+__process_settings() {
+	if [ -z "$TMUX_POWERLINE_SEG_EARTHQUAKE_DATA_PROVIDER" ]; then
+		export TMUX_POWERLINE_SEG_EARTHQUAKE_DATA_PROVIDER="${TMUX_POWERLINE_SEG_EARTHQUAKE_DATA_PROVIDER_DEFAULT}"
+	fi
+	if [ -z "$TMUX_POWERLINE_SEG_EARTHQUAKE_UPDATE_PERIOD" ]; then
+		export TMUX_POWERLINE_SEG_EARTHQUAKE_UPDATE_PERIOD="${TMUX_POWERLINE_SEG_EARTHQUAKE_UPDATE_PERIOD_DEFAULT}"
+	fi
+	if [ -z "$TMUX_POWERLINE_SEG_EARTHQUAKE_ALERT_TIME_WINDOW" ]; then
+		export TMUX_POWERLINE_SEG_EARTHQUAKE_ALERT_TIME_WINDOW="${TMUX_POWERLINE_SEG_EARTHQUAKE_ALERT_TIME_WINDOW_DEFAULT}"
+	fi
+	if [ -z "$TMUX_POWERLINE_SEG_EARTHQUAKE_TIME_FORMAT" ]; then
+		export TMUX_POWERLINE_SEG_EARTHQUAKE_TIME_FORMAT="${TMUX_POWERLINE_SEG_EARTHQUAKE_TIME_FORMAT_DEFAULT}"
+	fi
+	if [ -z "$TMUX_POWERLINE_SEG_EARTHQUAKE_MIN_MAGNITUDE" ]; then
+		export TMUX_POWERLINE_SEG_EARTHQUAKE_MIN_MAGNITUDE="${TMUX_POWERLINE_SEG_EARTHQUAKE_MIN_MAGNITUDE_DEFAULT}"
+	fi
+}
+
+__goo_earthquake() {
+	location=""
+	magnitude=""
+	magnitude_number=""
+	timestamp=""
+	if [[ 1 -eq 0 ]] && [[ -f "$tmp_file" ]]; then
+		if shell_is_osx; then
+			last_update=$(stat -f "%m" ${tmp_file})
+		elif shell_is_linux; then
+			last_update=$(stat -c "%Y" ${tmp_file})
+		fi
+		time_now=$(date +%s)
+
+		up_to_date=$(echo "(${time_now}-${last_update}) < ${update_period}" | bc)
+		if [ "$up_to_date" -eq 1 ]; then
+			__read_tmp_file
+		fi
+	fi
+
+	if [ -z "$magnitude" ]; then
+		# get the rss file, convert encoding to UTF-8, then delete windows carriage-returns
+		earthquake_data=$(curl --max-time 4 -s "http://weather.goo.ne.jp/earthquake/index.rdf" | iconv -f EUC-JP -t UTF-8 | tr -d "\r")
+		if [ "$?" -eq "0" ]; then
+            # This rss feed is not very clean or easy to use, but we will use it because
+            # this is all that can be found for now
+
+			# we grab the data from the title of the first item (most recent earthquake)
+			earthquake_data=${earthquake_data#*item\><title>}
+			# end our data at the end of the approx. time
+			earthquake_data=${earthquake_data%%頃*}
+
+			# pluck our data
+			location=$(echo $earthquake_data | awk '{print $2}')
+			magnitude=$(echo $earthquake_data | awk '{print $4}')
+			timestamp=${earthquake_data#*\(}
+
+			__convert_jp_magnitude
+			__convert_jp_timestamp
+
+			echo $location  >  $tmp_file
+			echo $magnitude >> $tmp_file
+			echo $timestamp >> $tmp_file
+		elif [ -f "$tmp_file" ]; then
+			__read_tmp_file
+		fi
+	fi
+	__convert_timestamp_to_fmt
+
+	# extract the numerical portion of magnitude
+	magnitude_number=$(echo $magnitude | sed -e 's/+//' -e 's/-//')
+
+	if [ -n "$magnitude" ]; then
+		if __check_alert_time_window && __check_min_magnitude ; then
+			echo "${location}${timestamp_fmt}:#[fg=colour0]${magnitude}"
+		fi
+	fi
+}
+
+__convert_jp_magnitude() {
+	magnitude=${magnitude#震度}
+	# simplify high-lower designation (only used in extreme cases: above 4)
+	if [[ "$magnitude" == *弱 ]] ; then
+		magnitude="-${magnitude%弱}"
+	elif [[ "$magnitude" == *強 ]] ; then
+		magnitude="+${magnitude%強}"
+	fi
+}
+
+__check_alert_time_window() {
+	[[ $(( ( $(date +%s) - $timestamp ) / 60 )) -lt $TMUX_POWERLINE_SEG_EARTHQUAKE_ALERT_TIME_WINDOW ]]
+}
+
+__check_min_magnitude() {
+	[[ $magnitude_number -ge $TMUX_POWERLINE_SEG_EARTHQUAKE_MIN_MAGNITUDE ]]
+}
+
+__convert_jp_timestamp() {
+	if shell_is_osx ; then
+		timestamp=$(date -j -f "%Y年%m月%d日 %H時%M分" "$timestamp" +"%s")
+	else
+		timestamp=$(echo $timestamp | $sed -e 's/年/-/' -e 's/月/-/' -e 's/日//' -e 's/時/:/' -e 's/分//')
+		timestamp=$(date -d "$timestamp" +"%s")
+	fi
+}
+
+__convert_timestamp_to_fmt() {
+	if shell_is_osx ; then
+		timestamp_fmt=$(date -r "$timestamp" +"$TMUX_POWERLINE_SEG_EARTHQUAKE_TIME_FORMAT")
+	else
+		timestamp_fmt=$(date -d "$timestamp" +"$TMUX_POWERLINE_SEG_EARTHQUAKE_TIME_FORMAT")
+	fi
+}
+
+__read_tmp_file() {
+	if [ ! -f "$tmp_file" ]; then
+		return
+	fi
+	IFS_bak="$IFS"
+	IFS=$'\n'
+	lines=($(cat ${tmp_file}))
+	IFS="$IFS_bak"
+	location="${lines[0]}"
+	magnitude="${lines[1]}"
+	timestamp="${lines[2]}"
+}

--- a/themes/default.sh
+++ b/themes/default.sh
@@ -39,6 +39,7 @@ fi
 
 if [ -z $TMUX_POWERLINE_RIGHT_STATUS_SEGMENTS ]; then
 	TMUX_POWERLINE_RIGHT_STATUS_SEGMENTS=(
+		#"earthquake 3 0" \
 		"pwd 89 211" \
 		"mailcount 9 255" \
 		"now_playing 234 37" \


### PR DESCRIPTION
I considered just using this myself since the audience would be limited,
but because it is a non trivial problem I have decided to ask you if you want
to add it to the main tmux-powerline repository.

I always find myself checking the earthquake alert system whenever
I feel a tremor. Here is a segment that can do that for me right in tmux.

This segment currently only looks at the 'goo' earthquake rss feed,
which takes it's information from the Japan Meteorological Agency.
This segment can be customized to display recent earthquakes that occur
in a given 'alert-window' above a certain magnitude threshhold. This
information should not and cannot be used as an early warning system,
but is helpful in alerting you to large quakes that may have happened
nearby.

It is not turned on in the default theme because mostly only people in Japan 
would use it.

This relies on goo's rss text formatting which is human-readable and not computer 
readable. If the format changes, this will break. I don't see that happening any time
soon though.
