### PR TITLE
Add 'snow/windy' to weather segment

### DIFF
--- a/segments/weather.sh
+++ b/segments/weather.sh
@@ -119,7 +119,7 @@ __get_condition_symbol() {
         	#echo "☂"
         	echo "☔"
         	;;
-    	"snow" | "mixed snow and sleet" | "snow flurries" | "light snow showers" | "blowing snow" | "sleet" | "hail" | "heavy snow" | "scattered snow showers" | "snow showers" | "light snow")
+    	"snow" | "mixed snow and sleet" | "snow flurries" | "light snow showers" | "blowing snow" | "sleet" | "hail" | "heavy snow" | "scattered snow showers" | "snow showers" | "light snow" | "snow/windy" )
         	#echo "☃"
         	echo "❅"
         	;;


### PR DESCRIPTION
I chose the snowflake for "snow/windy", but it may be interesting to inquire if we want to someday support more than one symbol. On the other hand, this may add unnecessary complexity to add multiple symbols. That being said, the weather segment tries to translate all possible human readable formats to a single symbol and it may be simpler to use something like `*snow*` and `*wind*`.
