### PR TITLE
Make ifstat.sh work on a mac

### DIFF
--- a/segments/ifstat.sh
+++ b/segments/ifstat.sh
@@ -17,9 +17,11 @@ run_segment() {
 				;;
 			wlan*) type="☫"
 				;;
+			en*) type=" "
+				;;
 		esac
 		if [ -n "${type}" ]; then
-			formate=$(echo "${formate} ${type} ⇊ %.2f⇈ %.2f")
+			formate=$(echo "${formate} ${type} ⇊ %.2f ⇈ %.2f")
 			holder=$(echo "${holder},\$$((index)),\$$((index+1))")
 		fi
 		index=$((index+2))


### PR DESCRIPTION
The network interface on my macbook air is en0 and isn't picked up by the ifstat.sh script even when ifstat is installed.

This changes just matches on en\* after eth\* and wlan*.

Also adds a space after the download speed to match the ifstat_sys script
