### PR TITLE
Weather: don't force specific grep location in bsd

### DIFF
--- a/segments/weather.sh
+++ b/segments/weather.sh
@@ -80,12 +80,9 @@ __yahoo_weather() {
             	exit 1
         	fi
 
-            if shell_is_bsd; then
-            	# You will need textproc/gnugrep with --enable-perl-regexp and PCRE compiled.
-            	gnugrep="/usr/local/bin/grep"
-            else
+            	# Assume latest grep is in PATH
             	gnugrep="grep"
-            fi
+
 			# <yweather:units temperature="F" distance="mi" pressure="in" speed="mph"/>
     		unit=$(echo "$weather_data" | "$gnugrep" -PZo "<yweather:units [^<>]*/>" | sed 's/.*temperature="\([^"]*\)".*/\1/')
     		condition=$(echo "$weather_data" | "$gnugrep" -PZo "<yweather:condition [^<>]*/>")


### PR DESCRIPTION
It is possible that grep can be installed in any locations, 
so we should not just assume '/user/local/bin' on BSD machines.
We must rely on the user reading the manual and updating grep.

For example, I have grep installed in `$HOME/.homebrew/bin` on an OSX machine with homebrew. I suspect MacPorts users would have the same problem.
