### PR TITLE
Compatibility fix for ZSH + TMUX

### DIFF
--- a/segments/date.sh
+++ b/segments/date.sh
@@ -17,7 +17,6 @@ __process_settings() {
 }
 
 run_segment() {
-        __process_settings
 	date +"$TMUX_POWERLINE_SEG_DATE_FORMAT"
 	return 0
 }


### PR DESCRIPTION
When curl downloads the data from yahoo, the variable content is empty even if we
specify the value in export section. Moved it to global variables to
make it look consistent and work correctly.
