### PR TITLE
ifstat segment made compatible with Mac OS X

### DIFF
--- a/segments/ifstat.sh
+++ b/segments/ifstat.sh
@@ -12,7 +12,7 @@ run_segment() {
 		sed="gsed"
 	fi
 
-	data=$(ifstat -S -q 1 1)
+	data=$(ifstat -z -S -q 1 1)
 	interfaces=$(echo -e "${data}" | head -n 1)
 	flow_data=$(echo -e "${data}" | tail -n 1 | ${sed} "s/\s\{1,\}/,/g")
 	index=1


### PR DESCRIPTION
The default /usr/bin/sed isn't compatible with the used regex. Thus, detect if `gsed` is available and use it, if so. Also, added `-z` switch to `ifstat` to ignore unplugged interfaces.
