### PR TITLE
Base Weather Icons on Sunrise/Sunset Times

### DIFF
--- a/segments/weather.sh
+++ b/segments/weather.sh
@@ -105,7 +105,7 @@ __yahoo_weather() {
 		degree=$(echo "${degree} + 273.15" | bc)
 		fi
 		condition_symbol=$(__get_condition_symbol "$condition" "$sunrise" "$sunset") 
-		echo "${condition_symbol} ${degree}°$(echo "$TMUX_POWERLINE_SEG_WEATHER_UNIT" | tr '[:lower:]' '[:upper:]')" | tee "{$tmp_file}"
+		echo "${condition_symbol} ${degree}°$(echo "$TMUX_POWERLINE_SEG_WEATHER_UNIT" | tr '[:lower:]' '[:upper:]')" | tee "${tmp_file}"
 	fi
 }
 


### PR DESCRIPTION
Rather than having a fixed sunrise/sunset time, use the data already being pulled from the weather server to adapt these times.

This is done by passing the time string pulled from the weather server for both sunrise and sunset through the `date` command. This value can then be compared against a `date +%H%M` to determine the appropriate symbol.

I've also reworked the weather file caching mechanism based on what seemed most appropriate. Let me know if there's a reason not to do it this way. Basically I am just echoing the full output of the weather segment to the temp file rather than the temperature data.

Finally, there is a typo and some tab/space inconsistencies resolved with this pull request.

Let me know if there are any issues or if anything needs further modification.
