### PR TITLE
segment/lan_ip: Fix for systems with multiple ips.

### DIFF
--- a/segments/lan_ip.sh
+++ b/segments/lan_ip.sh
@@ -12,19 +12,21 @@ run_segment() {
 		done
 	else
 		# Get the names of all attached NICs.
-		all_nics=$(ip addr show | cut -d ' ' -f2 | tr -d :)
-		all_nics=(${all_nics[@]//lo/})	 # Remove lo interface.
+		all_nics="$(ip addr show | cut -d ' ' -f2 | tr -d :)"
+		all_nics=("${all_nics[@]//lo/}")	 # Remove lo interface.
 
-		for nic in ${all_nics[@]}; do
+		for nic in "${all_nics[@]}"; do
 			# Parse IP address for the NIC.
-			lan_ip=$(ip addr show ${nic} | grep '\<inet\>' | tr -s ' ' | cut -d ' ' -f3)
+			lan_ip="$(ip addr show ${nic} | grep '\<inet\>' | tr -s ' ' | cut -d ' ' -f3)"
 			# Trim the CIDR suffix.
-			lan_ip=${lan_ip%/*}
+			lan_ip="${lan_ip%/*}"
+			# Only display the last entry
+			lan_ip="$(echo "$lan_ip" | tail -1)"
 
 			[ -n "$lan_ip" ] && break
 		done
 	fi
 
-        echo "ⓛ ${lan_ip-N/a}"
-        return 0
-    }
+	echo "ⓛ ${lan_ip-N/a}"
+	return 0
+}


### PR DESCRIPTION
- Old version returned a list of 3 IPs, breaking the layout.
- New version grabs the last IP, which appears to be the correct one
  that we want displayed, at least on this system.
- Also properly quoted variables and process substitution.
