### PR TITLE
Some Macs don't reach their max battery capacity

### DIFF
--- a/segments/battery.sh
+++ b/segments/battery.sh
@@ -59,9 +59,11 @@ __battery_osx() {
 					export curcap=$value;;
 				"ExternalConnected")
 					export extconnect=$value;;
+        "FullyCharged")
+          export fully_charged=$value;;
 			esac
 			if [[ -n $maxcap && -n $curcap && -n $extconnect ]]; then
-				if [[ "$curcap" == "$maxcap" ]]; then
+				if [[ "$curcap" == "$maxcap" || "$fully_charged" == "Yes" && $extconnect == "Yes"  ]]; then
 					return
 				fi
 				charge=$(( 100 * $curcap / $maxcap ))
@@ -126,7 +128,7 @@ __battery_osx() {
 
 
 		for i in `seq $TMUX_POWERLINE_SEG_BATTERY_NUM_HEARTS`; do
-			if [ $perc -lt 100 ]; then
+			if [ $perc -lt 99 ]; then
 				echo -n $HEART_EMPTY
 			else
 				echo -n $HEART_FULL


### PR DESCRIPTION
Checking ioreg for "FullyCharged" to be set to "Yes" and that's it's 
connected to power; if so don't display segment. Also dropped the max 
percentage to 99% (some older machines don't reach 100% charge capacity).
