### PR TITLE
Replace \t for the space, Add osx under the gnu stat command support

### DIFF
--- a/segments/wan_ip.sh
+++ b/segments/wan_ip.sh
@@ -2,38 +2,43 @@
 
 
 run_segment() {
-	local tmp_file="${TMUX_POWERLINE_DIR_TEMPORARY}/wan_ip.txt"
-	local wan_ip
+    local tmp_file="${TMUX_POWERLINE_DIR_TEMPORARY}/wan_ip.txt"
+    local wan_ip
 
-	if [ -f "$tmp_file" ]; then
-  	  if shell_is_osx || shell_is_bsd; then
-    	last_update=$(stat -f "%m" ${tmp_file})
-  	  elif shell_is_linux; then
-    	last_update=$(stat -c "%Y" ${tmp_file})
-  	  fi
+    if [ -f "$tmp_file" ]; then
+      if shell_is_osx || shell_is_bsd; then
+        stat >/dev/null 2>&1 && is_gnu_stat=false || is_gnu_stat=true
+        if [ "$is_gnu_stat" == "true" ];then
+            last_update=$(stat -c "%Y" ${tmp_file})
+        else
+            last_update=$(stat -f "%m" ${tmp_file})
+        fi
+      elif shell_is_linux || [ -z $is_gnu_stat]; then
+        last_update=$(stat -c "%Y" ${tmp_file})
+      fi
 
-  	  time_now=$(date +%s)
-  	  update_period=900
-  	  up_to_date=$(echo "(${time_now}-${last_update}) < ${update_period}" | bc)
+      time_now=$(date +%s)
+      update_period=900
+      up_to_date=$(echo "(${time_now}-${last_update}) < ${update_period}" | bc)
 
-  	  if [ "$up_to_date" -eq 1 ]; then
-    	wan_ip=$(cat ${tmp_file})
-  	  fi
-	fi
+      if [ "$up_to_date" -eq 1 ]; then
+        wan_ip=$(cat ${tmp_file})
+      fi
+    fi
 
-	if [ -z "$wan_ip" ]; then
-  	  wan_ip=$(curl --max-time 2 -s http://whatismyip.akamai.com/)
+    if [ -z "$wan_ip" ]; then
+      wan_ip=$(curl --max-time 2 -s http://whatismyip.akamai.com/)
 
-  	  if [ "$?" -eq "0" ]; then
-    	echo "${wan_ip}" > $tmp_file
-  	  elif [ -f "${tmp_file}" ]; then
-    	wan_ip=$(cat "$tmp_file")
-  	  fi
-	fi
+      if [ "$?" -eq "0" ]; then
+        echo "${wan_ip}" > $tmp_file
+      elif [ -f "${tmp_file}" ]; then
+        wan_ip=$(cat "$tmp_file")
+      fi
+    fi
 
-	if [ -n "$wan_ip" ]; then
-  	  echo "ⓦ ${wan_ip}"
-	fi
+    if [ -n "$wan_ip" ]; then
+      echo "ⓦ ${wan_ip}"
+    fi
 
-	return 0
+    return 0
 }


### PR DESCRIPTION
I use osx, but I'm not used bsd some commands by installing coreutil, use the gnu some commands, but in the 
segments/wan_ip.sh which use the stat command syntax is a problem, Because the default will allow me to use 

```
stat -f "%m" ${tmp_file}
```

I added  judgment
