### PR TITLE
Mailcount Segment: Escape osx gmail passwords that have special characters

### DIFF
--- a/segments/mailcount.sh
+++ b/segments/mailcount.sh
@@ -186,9 +186,9 @@ __count_mbox() {
 }
 
 __mac_keychain_get_pass() {
-	result=$(security 2>&1 > /dev/null find-internet-password -ga $1 -s $2)
+	result="$(security 2>&1 > /dev/null find-internet-password -ga $1 -s $2)"
 	if [ $? -eq 0 ]; then
-		TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_PASSWORD=$(echo $result | sed -e 's/password: \"\(.*\)\"/\1/g')
+		TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_PASSWORD=$(echo "$result" | sed -e 's/password: \"\(.*\)\"/\1/g')
 		return 0
 	fi
 	return 1


### PR DESCRIPTION
Escapes passwords from the OSX keychain that would result in special characters in the shell. If your password contains characters like '*' or '&' you can end up with subtle errors in the script.
