### PR TITLE
Fix mailcount xml fullcount tag parsing

### DIFF
--- a/segments/mailcount.sh
+++ b/segments/mailcount.sh
@@ -140,7 +140,12 @@ __count_gmail() {
 
     	# Hide password from command line (visible with e.g. ps(1)).
     	echo -e "user=${TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_USERNAME}@${TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_SERVER}\npassword=${TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_PASSWORD}" > "$tmp_wgetrc"
+        if shell_is_osx; then
+             mail=$(wget q -o - https://mail.google.com/a/${tmux_powerline_seg_mailcount_gmail_server}/feed/atom --config "$tmp_wgetrc" | grep -e -m 1 -o "<fullcount>(.*)</fullcount>"| sed -e 's,.*<fullcount>\([^<]*\)</fullcount>.*,\1,g')
+        else
 		mail=$(wget -q -O - https://mail.google.com/a/${TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_SERVER}/feed/atom --config "$tmp_wgetrc" | grep fullcount | sed 's/<[^0-9]*>//g')
+        fi
+
 		rm "$tmp_wgetrc"
 
 		if [ "$mail" != "" ]; then
@@ -153,7 +158,7 @@ __count_gmail() {
 	count=$(cat $tmp_file)
 	echo "$count"
 	return 0;
-} 
+}
 
 __count_maildir() {
 	if [ ! -d "$TMUX_POWERLINE_SEG_MAILCOUNT_MAILDIR_INBOX" ]; then

--- a/segments/mailcount.sh
+++ b/segments/mailcount.sh
@@ -140,12 +140,11 @@ __count_gmail() {
 
     	# Hide password from command line (visible with e.g. ps(1)).
     	echo -e "user=${TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_USERNAME}@${TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_SERVER}\npassword=${TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_PASSWORD}" > "$tmp_wgetrc"
-        if shell_is_osx; then
-             mail=$(wget q -o - https://mail.google.com/a/${tmux_powerline_seg_mailcount_gmail_server}/feed/atom --config "$tmp_wgetrc" | grep -e -m 1 -o "<fullcount>(.*)</fullcount>"| sed -e 's,.*<fullcount>\([^<]*\)</fullcount>.*,\1,g')
-        else
-		mail=$(wget -q -O - https://mail.google.com/a/${TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_SERVER}/feed/atom --config "$tmp_wgetrc" | grep fullcount | sed 's/<[^0-9]*>//g')
-        fi
-
+		if shell_is_osx; then
+			mail=$(wget -q -O - https://mail.google.com/a/${TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_SERVER}/feed/atom --config "$tmp_wgetrc" | grep -E -m 1 -o '<fullcount>(.*)</fullcount>' | sed -e 's,.*<fullcount>\([^<]*\)</fullcount>.*,\1,g')
+		else
+			mail=$(wget -q -O - https://mail.google.com/a/${TMUX_POWERLINE_SEG_MAILCOUNT_GMAIL_SERVER}/feed/atom --config "$tmp_wgetrc" | grep fullcount | sed 's/<[^0-9]*>//g')
+		fi
 		rm "$tmp_wgetrc"
 
 		if [ "$mail" != "" ]; then


### PR DESCRIPTION
Added OS X Yosemite 10.10.2 gmail mailcount compatibility: fixed xml fullcount-tag parsing