### PR TITLE
added OS X compability in ifstat_sys

### DIFF
--- a/segments/ifstat_sys.sh
+++ b/segments/ifstat_sys.sh
@@ -3,12 +3,21 @@
 
 run_segment() {
 	sleeptime="0.5"
-    iface="eth0"
-	RXB=$(</sys/class/net/"$iface"/statistics/rx_bytes)
-	TXB=$(</sys/class/net/"$iface"/statistics/tx_bytes)
-	sleep "$sleeptime"
-	RXBN=$(</sys/class/net/"$iface"/statistics/rx_bytes)
-	TXBN=$(</sys/class/net/"$iface"/statistics/tx_bytes)
+    if shell_is_osx; then
+        iface="en0"
+        RXB=$(netstat -i -b | grep -m 1 $iface | awk '{print $7}')
+        TXB=$(netstat -i -b | grep -m 1 $iface | awk '{print %10}')
+        sleep "$sleeptime"
+        RXBN=$(netstat -i -b | grep -m 1 $iface | awk '{print $7}')
+        TXBN=$(netstat -i -b | grep -m 1 $iface | awk '{print %10}')
+    else
+        iface="eth0"
+	    RXB=$(</sys/class/net/"$iface"/statistics/rx_bytes)
+	    TXB=$(</sys/class/net/"$iface"/statistics/tx_bytes)
+	    sleep "$sleeptime"
+	    RXBN=$(</sys/class/net/"$iface"/statistics/rx_bytes)
+	    TXBN=$(</sys/class/net/"$iface"/statistics/tx_bytes)
+    fi
 	RXDIF=$(echo "$((RXBN - RXB)) / 1024 / ${sleeptime}" | bc )
 	TXDIF=$(echo "$((TXBN - TXB)) / 1024 / ${sleeptime}" | bc )
 


### PR DESCRIPTION
There is no /sys/ in OS X, so i get I/O bytes info on en0 via netstat.