### PR TITLE
fix newline in file

### DIFF
--- a/segments/now_playing.sh
+++ b/segments/now_playing.sh
@@ -130,8 +130,8 @@ __np_mpd() {
 
 __np_file() {
 
-       np=$(cat $TMUX_POWERLINE_SEG_NOW_PLAYING_FILE_NAME)
-       echo "$np"
+        np=$(cat $TMUX_POWERLINE_SEG_NOW_PLAYING_FILE_NAME | tr '\n' '|')
+        echo "$np"
 }
 
 


### PR DESCRIPTION
New line character in file content, makes things awry and eats up the time and weather segments. This minor fix will make the contents of the file come into a single file with a | delimiter. 