### PR TITLE
show error when rainbarf is not found

### DIFF
--- a/segments/rainbarf.sh
+++ b/segments/rainbarf.sh
@@ -3,6 +3,7 @@
 run_segment() {
 	type rainbarf >/dev/null 2>&1
 	if [ "$?" -ne 0 ]; then
+		echo 'rainbarf was not found'
 		return
 	fi
 

--- a/themes/default.sh
+++ b/themes/default.sh
@@ -48,7 +48,7 @@ if [ -z $TMUX_POWERLINE_RIGHT_STATUS_SEGMENTS ]; then
 		#"tmux_mem_cpu_load 234 136" \
 		"battery 137 127" \
 		"weather 37 255" \
-		#"rainbarf 0 0" \
+		#"rainbarf 0 ${TMUX_POWERLINE_DEFAULT_FOREGROUND_COLOR}" \
 		#"xkb_layout 125 117" \
 		"date_day 235 136" \
 		"date 235 136 ${TMUX_POWERLINE_SEPARATOR_LEFT_THIN}" \


### PR DESCRIPTION
I installed `rainbarf` via Linuxbrew and enabled rainbarf segment, but rainbarf segment was not shown. It took time to find the cause of this phenomenon.

I modified to show error when rainbarf is not found, and foreground color because this error can be read.