### PR TITLE
replaced battery equation with a more accurate osx command

### DIFF
--- a/segments/battery.sh
+++ b/segments/battery.sh
@@ -66,7 +66,7 @@ __battery_osx() {
 				if [[ "$curcap" == "$maxcap" || "$fully_charged" == "Yes" && $extconnect == "Yes"  ]]; then
 					return
 				fi
-				charge=$(( 100 * $curcap / $maxcap ))
+				charge=`pmset -g batt | grep -o "[0-9][0-9]*\%" | rev | cut -c 2- | rev`
 				if [[ "$extconnect" == "Yes" ]]; then
 					echo "$charge"
 				else


### PR DESCRIPTION
Apparently getting the battery current capacity and dividing that over the max capacity gives a wrong estimate about the battery remaining percentage, at least from Mac OS point of view.
(I am assuming they have a statistical model to base the remaining time on, factoring in the user behaviour, the open apps...etc)

I found that using `pmset` gives exactly the percentage that appears on top screen. so I decided that is a more accurate measure, instead of the annoyance of having two different values.

I left the other command with its variables intact, in order not to break the current behaviour.