### PR TITLE
updated uptime.sh with support for alternate 'grep' on Mac OS X

### DIFF
--- a/segments/uptime.sh
+++ b/segments/uptime.sh
@@ -1,6 +1,29 @@
 # Prints the uptime.
 
+
+if shell_is_bsd; then
+    TMUX_POWERLINE_SEG_UPTIME_GREP_DEFAULT="/usr/local/bin/grep"
+else
+    TMUX_POWERLINE_SEG_UPTIME_GREP_DEFAULT="grep"
+fi
+
+__process_settings() {
+    if [ -z "$TMUX_POWERLINE_SEG_UPTIME_GREP" ]; then
+        export TMUX_POWERLINE_SEG_UPTIME_GREP="${TMUX_POWERLINE_SEG_UPTIME_GREP_DEFAULT}"
+    fi
+}
+
+generate_segmentrc() {
+    read -d '' rccontents  << EORC
+# Name of GNU grep binary if in PATH, or path to it.
+export TMUX_POWERLINE_SEG_UPTIME_GREP="${TMUX_POWERLINE_SEG_UPTIME_GREP_DEFAULT}"
+EORC
+    echo "$rccontents"
+}
+
 run_segment() {
-	uptime | grep -PZo "(?<=up )[^,]*"
-	return 0
+    # Assume latest grep is in PATH
+    gnugrep="${TMUX_POWERLINE_SEG_UPTIME_GREP}"
+    uptime | $gnugrep -PZo "(?<=up )[^,]*"
+    return 0
 }


### PR DESCRIPTION
uptime.sh currently doesn't support using a different 'grep' command, this breaks in Mac OS X as default grep is much older version

i have added support for switching default grep so that uptime.sh works in Mac OS X