### PR TITLE
Modify don't create index.lock on vcs_modified and vcs_others.sh

### DIFF
--- a/segments/vcs_modified.sh
+++ b/segments/vcs_modified.sh
@@ -33,7 +33,7 @@ __parse_git_stats(){
 	[[ -z $(git rev-parse --git-dir 2> /dev/null) ]] && return
 
 	# return the number of modified but not staged items
-	modified=$(git status -s | cut -c 2 | awk '$1 != "" && $1 != "?" { print $1  }' | wc -l)
+	modified=$(git ls-files --modified `git rev-parse --show-cdup` | wc -l)
 	echo $modified
 }
 __parse_hg_stats(){

--- a/segments/vcs_others.sh
+++ b/segments/vcs_others.sh
@@ -32,7 +32,7 @@ __parse_git_stats(){
 	[[ -z $(git rev-parse --git-dir 2> /dev/null) ]] && return
 
 	# return the number of untracked items
-	other=$(git status -s | awk '$1 == "??" { print $1  }' | wc -l)
+	other=$(git ls-files --others --exclude-standard `git rev-parse --show-cdup` | wc -l)
 	echo $other
 }
 __parse_hg_stats(){


### PR DESCRIPTION
Recently, I encount lot of index.lock on my local git repository. To the best of my knowledge, git-status command on vcs_xxx.sh creates lock file. So I modified to use ls-files instead of git-status.