### PR TITLE
Change to display without omitting the branch name

### DIFF
--- a/segments/vcs_branch.sh
+++ b/segments/vcs_branch.sh
@@ -49,7 +49,7 @@ __parse_git_branch() {
 	fi
 
 	# Clean off unnecessary information.
-	branch=${branch##*/}
+	branch=${branch#refs\/heads\/}
 
 	echo  -n "#[fg=colour${git_colour}]${branch_symbol} #[fg=colour${TMUX_POWERLINE_CUR_SEGMENT_FG}]${branch}"
 }


### PR DESCRIPTION
Branch name is displayed as "XXXXX" when there is a branch called "topic / XXXXX".
So I want to display without omitting the branch name.

## result
![image](https://cloud.githubusercontent.com/assets/3356758/19831271/cda5ba10-9e40-11e6-91dc-6a3daf6739f2.png)
