### PR TITLE
Use tmux to query the cwd of the active pane

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ bind C-[ run '~/path/to/tmux-powerline/mute_powerline.sh left'		# Mute left stat
 bind C-] run '~/path/to/tmux-powerline/mute_powerline.sh right'		# Mute right statusbar.
 ```
 
+## For tmux versions < 2.1
+
 Some segments e.g. cwd and cvs_branch needs to find the current working directory of the active pane. To achieve this we let tmux save the path each time the shell prompt is displayed. Put the line below in your `~/.bashrc` or where you define you PS1 variable. zsh users can put it in e.g. `~/.zshrc` and may change `PS1` to `PROMPT` (but that's not necessary).
 
 ```bash
@@ -137,6 +139,8 @@ If the active shell is Fish, PS1 is not being set normally. Instead, it has a `f
 ```fish
 if set -q TMUX; tmux setenv TMUXPWD_(tmux display -p "#D" | tr -d '%') $PWD; end
 ```
+
+If you have a recent version of tmux (&ge; 2.1), there is no need to redefine the PS1 variable since tmux can be called directly to query the working directory of the active pane.
 
 # Configuration
 

--- a/lib/tmux_adapter.sh
+++ b/lib/tmux_adapter.sh
@@ -1,12 +1,32 @@
 # Get the current path in the segment.
-get_tmux_cwd() {
-	local env_name=$(tmux display -p "TMUXPWD_#D" | tr -d %)
-	local env_val=$(tmux show-environment | grep --color=never "$env_name")
-	# The version below is still quite new for tmux. Uncomment this in the future :-)
-	#local env_val=$(tmux show-environment "$env_name" 2>&1)
+MIN_MAJOR_VERSION="2"
+MIN_MINOR_VERSION="1"
+TMUX_VERSION="$(tmux -V)"
 
-	if [[ ! $env_val =~ "unknown variable" ]]; then
-		local tmux_pwd=$(echo "$env_val" | sed 's/^.*=//')
-		echo "$tmux_pwd"
+if [[ "${TMUX_VERSION}" =~ .*([[:digit:]]+)\.([[:digit:]]+) ]]; then
+	TMUX_MAJOR_VERSION="${BASH_REMATCH[1]}"
+	TMUX_MINOR_VERSION="${BASH_REMATCH[2]}"
+	if [[ ("${TMUX_MAJOR_VERSION}" -gt "${MIN_MAJOR_VERSION}") || (("${TMUX_MAJOR_VERSION}" -eq "${MIN_MAJOR_VERSION}") && ("${TMUX_MINOR_VERSION}" -ge "${MIN_MINOR_VERSION}")) ]]; then
+		get_tmux_cwd() {
+			tmux display -p -F "#{pane_current_path}"
+		}
 	fi
-}
+fi
+
+if [[ -z "$(type -t get_tmux_cwd)" ]]; then
+	get_tmux_cwd() {
+		local env_name=$(tmux display -p "TMUXPWD_#D" | tr -d %)
+		local env_val=$(tmux show-environment | grep --color=never "$env_name")
+		# The version below is still quite new for tmux. Uncomment this in the future :-)
+		#local env_val=$(tmux show-environment "$env_name" 2>&1)
+
+		if [[ ! $env_val =~ "unknown variable" ]]; then
+			local tmux_pwd=$(echo "$env_val" | sed 's/^.*=//')
+			echo "$tmux_pwd"
+		fi
+	}
+fi
+
+unset MIN_MAJOR_VERSION
+unset MIN_MINOR_VERSION
+unset TMUX_VERSION


### PR DESCRIPTION
Since version 2.1 `tmux display` can be used to query the current
working directory in the active pane. This commit makes use of this
query function if tmux is recent enough. Otherwise, the old query code
is used as a fallback.

Fixes #188 