### PR TITLE
Fix weather segment on OSX

### DIFF
--- a/segments/weather.sh
+++ b/segments/weather.sh
@@ -6,7 +6,14 @@ update_period=600
 TMUX_POWERLINE_SEG_WEATHER_DATA_PROVIDER_DEFAULT="yahoo"
 TMUX_POWERLINE_SEG_WEATHER_UNIT_DEFAULT="c"
 TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD_DEFAULT="600"
-if shell_is_bsd; then
+
+# Your location. Find a code that works for you:
+# 1. Go to Yahoo weather http://weather.yahoo.com/
+# 2. Find the weather for you location
+# 3. Copy the last numbers in that URL. e.g. "http://weather.yahoo.com/united-states/california/newport-beach-12796587/" has the numbers "12796587"
+TMUX_POWERLINE_SEG_WEATHER_LOCATION=""
+
+if shell_is_bsd  && [ -f /user/local/bin/grep  ]; then
 	TMUX_POWERLINE_SEG_WEATHER_GREP_DEFAULT="/usr/local/bin/grep"
 else
 	TMUX_POWERLINE_SEG_WEATHER_GREP_DEFAULT="grep"
@@ -23,12 +30,6 @@ export TMUX_POWERLINE_SEG_WEATHER_UNIT="${TMUX_POWERLINE_SEG_WEATHER_UNIT_DEFAUL
 export TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD="${TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD_DEFAULT}"
 # Name of GNU grep binary if in PATH, or path to it.
 export TMUX_POWERLINE_SEG_WEATHER_GREP="${TMUX_POWERLINE_SEG_WEATHER_GREP_DEFAULT}"
-
-# Your location. Find a code that works for you:
-# 1. Go to Yahoo weather http://weather.yahoo.com/
-# 2. Find the weather for you location
-# 3. Copy the last numbers in that URL. e.g. "http://weather.yahoo.com/united-states/california/newport-beach-12796587/" has the numbers "12796587"
-export TMUX_POWERLINE_SEG_WEATHER_LOCATION=""
 EORC
 	echo "$rccontents"
 }


### PR DESCRIPTION
**Following PR:**
 - Stops using `/usr/local/bin/grep` if path is not existent for OSX (maybe previously was installed using brew, and this puts the stuff under `/usr/local/`). Current OSX grep works fine, and is no longer part of `/usr/local`. But keeping the previous path for compatibility.

 - Moves `TMUX_POWERLINE_SEG_WEATHER_LOCATION` where it can be used. Previously that var was not being populated following the instructions.

**Output proof:**

<img width="275" alt="screen shot 2018-03-23 at 23 20 25" src="https://user-images.githubusercontent.com/1070554/37857152-db690700-2ef0-11e8-959f-38ece6bd3a74.png">
