### PR TITLE
New Segment: disk_usage

### DIFF
--- a/segments/disk_usage.sh
+++ b/segments/disk_usage.sh
@@ -12,7 +12,7 @@ EORC
 
 run_segment() {
 	__process_settings
-    percentage=`df ${TMUX_POWERLINE_SEG_DISK_USAGE_FILESYSTEM} | awk '{print $5}' | tail -n1`
+    percentage=$(df ${TMUX_POWERLINE_SEG_DISK_USAGE_FILESYSTEM} | awk '{print $5}' | tail -n1)
     echo "${TMUX_POWERLINE_SEG_DISK_USAGE_FILESYSTEM} ${percentage}"
 	return 0
 }

--- a/segments/disk_usage.sh
+++ b/segments/disk_usage.sh
@@ -1,0 +1,25 @@
+# Print used disk space on the specified filesystem
+
+TMUX_POWERLINE_SEG_DISK_USAGE_FILESYSTEM_DEFAULT="/"
+
+generate_segmentrc() {
+	read -d '' rccontents  << EORC
+# Filesystem to retrieve disk space information. Any from the filesystems available (run "df | awk '{print $1}'" to check them).
+export TMUX_POWERLINE_SEG_DISK_USAGE_FILESYSTEM="${TMUX_POWERLINE_SEG_DISK_USAGE_FILESYSTEM_DEFAULT}"
+EORC
+	echo "$rccontents"
+}
+
+run_segment() {
+	__process_settings
+    percentage=`df ${TMUX_POWERLINE_SEG_DISK_USAGE_FILESYSTEM} | awk '{print $5}' | tail -n1`
+    echo "${TMUX_POWERLINE_SEG_DISK_USAGE_FILESYSTEM} ${percentage}"
+	return 0
+}
+
+__process_settings() {
+	if [ -z "$TMUX_POWERLINE_SEG_DISK_USAGE_FILESYSTEM" ]; then
+        export TMUX_POWERLINE_SEG_DISK_USAGE_FILESYSTEM="${TMUX_POWERLINE_SEG_DISK_USAGE_FILESYSTEM_DEFAULT}"
+    fi
+    return 0
+}


### PR DESCRIPTION
Following PR:
 - Adds a new segment to display a specific filesystem usage
 - Allows customizing the desired filesystem ( `/` as default)

Output example using `/` filesystem:

<img width="288" alt="screen shot 2018-03-25 at 20 11 39" src="https://user-images.githubusercontent.com/1070554/37878985-c0de0f88-3068-11e8-87c1-d64005cf6f60.png">
