### PR TITLE
Add weather location to tmux-powerlinerc and Change generate_rc.sh

### DIFF
--- a/segments/weather.sh
+++ b/segments/weather.sh
@@ -11,7 +11,7 @@ TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD_DEFAULT="600"
 # 1. Go to Yahoo weather http://weather.yahoo.com/
 # 2. Find the weather for you location
 # 3. Copy the last numbers in that URL. e.g. "http://weather.yahoo.com/united-states/california/newport-beach-12796587/" has the numbers "12796587"
-TMUX_POWERLINE_SEG_WEATHER_LOCATION=""
+TMUX_POWERLINE_SEG_WEATHER_LOCATION_DEFAULT=""
 
 if shell_is_bsd  && [ -f /user/local/bin/grep  ]; then
 	TMUX_POWERLINE_SEG_WEATHER_GREP_DEFAULT="/usr/local/bin/grep"
@@ -68,8 +68,11 @@ __process_settings() {
 		export TMUX_POWERLINE_SEG_WEATHER_GREP="${TMUX_POWERLINE_SEG_WEATHER_GREP_DEFAULT}"
 	fi
 	if [ -z "$TMUX_POWERLINE_SEG_WEATHER_LOCATION" ]; then
-		echo "No weather location specified.";
-		exit 8
+		if [ -z "$TMUX_POWERLINE_SEG_WEATHER_LOCATION_DEFAULT" ]; then
+			echo "No weather location specified.";
+			exit 8
+		fi
+		export TMUX_POWERLINE_SEG_WEATHER_LOCATION=${TMUX_POWERLINE_SEG_WEATHER_LOCATION_DEFAULT}
 	fi
 }
 

--- a/segments/weather.sh
+++ b/segments/weather.sh
@@ -7,11 +7,11 @@ TMUX_POWERLINE_SEG_WEATHER_DATA_PROVIDER_DEFAULT="yahoo"
 TMUX_POWERLINE_SEG_WEATHER_UNIT_DEFAULT="c"
 TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD_DEFAULT="600"
 
-# Your location. Find a code that works for you:
-# 1. Go to Yahoo weather http://weather.yahoo.com/
-# 2. Find the weather for you location
-# 3. Copy the last numbers in that URL. e.g. "http://weather.yahoo.com/united-states/california/newport-beach-12796587/" has the numbers "12796587"
-TMUX_POWERLINE_SEG_WEATHER_LOCATION=""
+# If you want to set your location, set TMUX_POWERLINE_SEG_WEATHER_LOCATION in the tmux-powerlinerc file.
+# 1. You create tmux-powerlinerc file.
+#    $ ./generate_rc.sh
+#    $ mv ~/.tmux-powerlinerc.default ~/.tmux-powerlinerc
+# 2. You set TMUX_POWERLINE_SEG_WEATHER_LOCATION.
 
 if shell_is_bsd  && [ -f /user/local/bin/grep  ]; then
 	TMUX_POWERLINE_SEG_WEATHER_GREP_DEFAULT="/usr/local/bin/grep"

--- a/segments/weather.sh
+++ b/segments/weather.sh
@@ -11,7 +11,7 @@ TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD_DEFAULT="600"
 # 1. Go to Yahoo weather http://weather.yahoo.com/
 # 2. Find the weather for you location
 # 3. Copy the last numbers in that URL. e.g. "http://weather.yahoo.com/united-states/california/newport-beach-12796587/" has the numbers "12796587"
-TMUX_POWERLINE_SEG_WEATHER_LOCATION_DEFAULT=""
+TMUX_POWERLINE_SEG_WEATHER_LOCATION=""
 
 if shell_is_bsd  && [ -f /user/local/bin/grep  ]; then
 	TMUX_POWERLINE_SEG_WEATHER_GREP_DEFAULT="/usr/local/bin/grep"
@@ -68,11 +68,8 @@ __process_settings() {
 		export TMUX_POWERLINE_SEG_WEATHER_GREP="${TMUX_POWERLINE_SEG_WEATHER_GREP_DEFAULT}"
 	fi
 	if [ -z "$TMUX_POWERLINE_SEG_WEATHER_LOCATION" ]; then
-		if [ -z "$TMUX_POWERLINE_SEG_WEATHER_LOCATION_DEFAULT" ]; then
-			echo "No weather location specified.";
-			exit 8
-		fi
-		export TMUX_POWERLINE_SEG_WEATHER_LOCATION=${TMUX_POWERLINE_SEG_WEATHER_LOCATION_DEFAULT}
+		echo "No weather location specified.";
+		exit 8
 	fi
 }
 

--- a/segments/weather.sh
+++ b/segments/weather.sh
@@ -30,6 +30,11 @@ export TMUX_POWERLINE_SEG_WEATHER_UNIT="${TMUX_POWERLINE_SEG_WEATHER_UNIT_DEFAUL
 export TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD="${TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD_DEFAULT}"
 # Name of GNU grep binary if in PATH, or path to it.
 export TMUX_POWERLINE_SEG_WEATHER_GREP="${TMUX_POWERLINE_SEG_WEATHER_GREP_DEFAULT}"
+# Your location. Find a code that works for you:
+# 1. Go to Yahoo weather http://weather.yahoo.com/
+# 2. Find the weather for you location
+# 3. Copy the last numbers in that URL. e.g. "http://weather.yahoo.com/united-states/california/newport-beach-12796587/" has the numbers "12796587"
+TMUX_POWERLINE_SEG_WEATHER_LOCATION=""
 EORC
 	echo "$rccontents"
 }


### PR DESCRIPTION
## Proposal

I would like to add **TMUX_POWERLINE_SEG_WEATHER_LOCATION** to *tmux-powerlinerc*.

```bash
# weather.sh {
        # The data provider to use. Currently only "yahoo" is supported.
        export TMUX_POWERLINE_SEG_WEATHER_DATA_PROVIDER="yahoo"
        # What unit to use. Can be any of {c,f,k}.
        export TMUX_POWERLINE_SEG_WEATHER_UNIT="c"
        # How often to update the weather in seconds.
        export TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD="600"
        # Name of GNU grep binary if in PATH, or path to it.
        export TMUX_POWERLINE_SEG_WEATHER_GREP="grep"
        # Your location. Find a code that works for you:
        # 1. Go to Yahoo weather http://weather.yahoo.com/
        # 2. Find the weather for you location
        # 3. Copy the last numbers in that URL. e.g. "http://weather.yahoo.com/united-states/california/newport-beach-12796587/" has the numbers "12796587"
        TMUX_POWERLINE_SEG_WEATHER_LOCATION="XXXXXXXXX"
# }
```

## Change point

- TMUX_POWERLINE_SEG_WEATHER_LOCATION is now added to tmux-powerlinerc when generate_rc.sh is executed.
- Added TMUX_POWERLINE_SEG_WEATHER_LOCATION_DEFAULT to read TMUX POWERLINE SEG_WEATHER_LOCATION of tmux-powerlinerc.
- If the TMUX_POWERLINE_SEG_WEATHER_LOCATION_DEFAULT is empty, "No weather location specified" will be displayed.