### PR TITLE
Automatically powerline-ify the window status elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,15 +122,12 @@ set-option -g status-left-length 60
 set-option -g status-right-length 90
 set-option -g status-left "#(~/path/to/tmux-powerline/powerline.sh left)"
 set-option -g status-right "#(~/path/to/tmux-powerline/powerline.sh right)"
+set-hook -g session-created 'run-shell "~/path/to/tmux-powerline/powerline.sh init"' # prettifies the window-status segments
 ```
 
 Set the maximum lengths to something that suits your configuration of segments and size of terminal (the maximum segments length will be handled better in the future).
 
-The window list can be powerlineified if you'd like by adding the following line to the same file:
-
-```vim
-set-window-option -g window-status-current-format "#[fg=colour235, bg=colour27]⮀#[fg=colour255, bg=colour27] #I ⮁ #W #[fg=colour27, bg=colour235]⮀"
-```
+The window-status configuration is run only when a session is created, so re-running init is required to refresh the window status formats.
 
 You can toggle the visibility of the statusbars by adding the following lines:
 

--- a/lib/arg_processing.sh
+++ b/lib/arg_processing.sh
@@ -1,9 +1,9 @@
 #! Check script arguments.
 
 check_arg_side() {
-	local side="$1"		
-	if ! [ "$side" ==  "left" -o "$side" == "right" ]; then
-		echo "Argument must be the side to handle {left, right} and not \"${side}\"."
+	local side="$1"
+	if ! [ "$side" ==  "left" -o "$side" == "right" -o "$side" == "init" ]; then
+		echo "Argument must be the side to handle {left, right} or {init} and not \"${side}\"."
     	exit 1
 	fi
 }

--- a/lib/powerline.sh
+++ b/lib/powerline.sh
@@ -16,6 +16,54 @@ print_powerline() {
 	__process_powerline
 }
 
+format() {
+    local type="$1"
+
+    case $type in
+	inverse)
+		echo "fg=colour$TMUX_POWERLINE_DEFAULT_BACKGROUND_COLOR,bg=colour$TMUX_POWERLINE_DEFAULT_FOREGROUND_COLOR,nobold,noitalics,nounderscore"
+		;;
+	regular)
+		echo "fg=colour$TMUX_POWERLINE_DEFAULT_FOREGROUND_COLOR,bg=colour$TMUX_POWERLINE_DEFAULT_BACKGROUND_COLOR,nobold,noitalics,nounderscore"
+		;;
+	*)
+		;;
+    esac
+}
+
+init_powerline() {
+	if [ -z $TMUX_POWERLINE_WINDOW_STATUS_CURRENT ]; then
+		TMUX_POWERLINE_WINDOW_STATUS_CURRENT=(
+			"#[$(format inverse)]" \
+			"$TMUX_POWERLINE_DEFAULT_LEFTSIDE_SEPARATOR" \
+			" #I#F " \
+			"$TMUX_POWERLINE_SEPARATOR_RIGHT_THIN" \
+			" #W " \ "#[$(format regular)]" \
+			"$TMUX_POWERLINE_DEFAULT_LEFTSIDE_SEPARATOR"
+		)
+	fi
+
+	if [ -z $TMUX_POWERLINE_WINDOW_STATUS_STYLE ]; then
+		TMUX_POWERLINE_WINDOW_STATUS_STYLE=(
+			"$(format regular)"
+		)
+	fi
+
+	if [ -z $TMUX_POWERLINE_WINDOW_STATUS_STYLE ]; then
+		TMUX_POWERLINE_WINDOW_STATUS_FORMAT=(
+			"#[$(format regular)]" \
+			"  #I#{?window_flags,#F, } " \
+			"$TMUX_POWERLINE_SEPARATOR_RIGHT_THIN" \
+			" #W "
+		)
+	fi
+
+	tmux set-option -g window-status-current-format "$(printf '%s' "${TMUX_POWERLINE_WINDOW_STATUS_CURRENT[@]}")"
+	tmux set-option -g window-status-format "$(printf '%s' "${TMUX_POWERLINE_WINDOW_STATUS_FORMAT[@]}")"
+	tmux set-option -g window-status-style "$(printf '%s' "${TMUX_POWERLINE_WINDOW_STATUS_STYLE[@]}")"
+	tmux set-option -g status-style "fg=colour$TMUX_POWERLINE_DEFAULT_FOREGROUND_COLOR,bg=colour$TMUX_POWERLINE_DEFAULT_BACKGROUND_COLOR"
+}
+
 __process_segment_defaults() {
 	for segment_index in "${!input_segments[@]}"; do
 		local input_segment=(${input_segments[$segment_index]})
@@ -139,4 +187,3 @@ __check_platform() {
 		 echo "Unknown platform; modify config/shell.sh"  &1>&2
 	fi
 }
-

--- a/powerline.sh
+++ b/powerline.sh
@@ -16,7 +16,11 @@ source "${TMUX_POWERLINE_DIR_LIB}/rcfile.sh"
 if ! powerline_muted "$1"; then
 	process_settings
 	check_arg_side "$1"
-	print_powerline "$1"
+	if [ $1 == "init" ]; then
+		init_powerline
+	else
+		print_powerline "$1"
+	fi
 fi
 
 exit 0

--- a/themes/default.sh
+++ b/themes/default.sh
@@ -18,6 +18,35 @@ TMUX_POWERLINE_DEFAULT_FOREGROUND_COLOR=${TMUX_POWERLINE_DEFAULT_FOREGROUND_COLO
 TMUX_POWERLINE_DEFAULT_LEFTSIDE_SEPARATOR=${TMUX_POWERLINE_DEFAULT_LEFTSIDE_SEPARATOR:-$TMUX_POWERLINE_SEPARATOR_RIGHT_BOLD}
 TMUX_POWERLINE_DEFAULT_RIGHTSIDE_SEPARATOR=${TMUX_POWERLINE_DEFAULT_RIGHTSIDE_SEPARATOR:-$TMUX_POWERLINE_SEPARATOR_LEFT_BOLD}
 
+# See man tmux.conf for additional formatting options for the status line.
+# The `format regular` and `format inverse` functions are provided as conveinences
+
+if [ -z $TMUX_POWERLINE_WINDOW_STATUS_CURRENT ]; then
+	TMUX_POWERLINE_WINDOW_STATUS_CURRENT=(
+		"#[$(format inverse)]" \
+		"$TMUX_POWERLINE_DEFAULT_LEFTSIDE_SEPARATOR" \
+		" #I#F " \
+		"$TMUX_POWERLINE_SEPARATOR_RIGHT_THIN" \
+		" #W " \
+		"#[$(format regular)]" \
+		"$TMUX_POWERLINE_DEFAULT_LEFTSIDE_SEPARATOR"
+	)
+fi
+
+if [ -z $TMUX_POWERLINE_WINDOW_STATUS_STYLE ]; then
+	TMUX_POWERLINE_WINDOW_STATUS_STYLE=(
+		"$(format regular)"
+	)
+fi
+
+if [ -z $TMUX_POWERLINE_WINDOW_STATUS_FORMAT ]; then
+	TMUX_POWERLINE_WINDOW_STATUS_FORMAT=(
+		"#[$(format regular)]" \
+		"  #I#{?window_flags,#F, } " \
+		"$TMUX_POWERLINE_SEPARATOR_RIGHT_THIN" \
+		" #W "
+	)
+fi
 
 # Format: segment_name background_color foreground_color [non_default_separator]
 


### PR DESCRIPTION
Powerline-ifying the window status elements in the tmux status bar requires me to type obnoxious and difficult to read tmux formatting commands.  Introduce a `powerline.sh init` command which sets these options on connect - ensuring my tmux status bar is super cool and I can impress all of my nerd friends.

![Screen Shot 2021-12-16 at 12 12 49 AM](https://user-images.githubusercontent.com/149870/146333151-fe9ca8a5-31b2-4c5d-a025-50eae6a8f2c3.png)

