### PR TITLE
Show current keyboard layout for Gnome40

### DIFF
--- a/segments/gnome4_layout.sh
+++ b/segments/gnome4_layout.sh
@@ -1,0 +1,13 @@
+# Print the currently used keyboard layout
+# Works with Gnome 40
+# Set smaller update interval in .tmux.conf: 'set-option -g status-interval 1'
+# Exit if platform is not linux as this script is dependant on Linux and Gnome DE
+
+run_segment() {
+	if ! shell_is_linux; then
+		return 1
+	fi
+
+cur_layout=$(gsettings get org.gnome.desktop.input-sources mru-sources | awk -F"'" '{print $4}')
+	echo "⌨  $cur_layout"
+}

--- a/segments/gnome4_layout.sh
+++ b/segments/gnome4_layout.sh
@@ -9,5 +9,8 @@ run_segment() {
 	fi
 
 cur_layout=$(gsettings get org.gnome.desktop.input-sources mru-sources | awk -F"'" '{print $4}')
+	ecode=$? 
+        test $ecode -eq 0 || return $ecode
 	echo "⌨  $cur_layout"
+	return 0
 }


### PR DESCRIPTION
Use Gnome40 gsettings to get and show current used keyboard layout.