### PR TITLE
Determine the absolute path of the script more accurately.

### DIFF
--- a/powerline.sh
+++ b/powerline.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export TMUX_POWERLINE_DIR_HOME="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+export TMUX_POWERLINE_DIR_HOME="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 source "${TMUX_POWERLINE_DIR_HOME}/config/helpers.sh"
 source "${TMUX_POWERLINE_DIR_HOME}/config/paths.sh"

--- a/powerline.sh
+++ b/powerline.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export TMUX_POWERLINE_DIR_HOME="$(dirname $0)"
+export TMUX_POWERLINE_DIR_HOME="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 source "${TMUX_POWERLINE_DIR_HOME}/config/helpers.sh"
 source "${TMUX_POWERLINE_DIR_HOME}/config/paths.sh"


### PR DESCRIPTION
This allows creating a symlink to the script and invoking this script
using the symlink.

## The issue fixed by this pull request:

I created a symlink to the script as follows:

```
$ ln -s /data/dev-stuff/git-repos/tmux-powerline/powerline.sh ~/.local/bin/powerline

$ ls -l ~/.local/bin/tmux-powerline 
lrwxrwxrwx 1 ash ash 53 Jan 30 18:09 /home/ash/.local/bin/tmux-powerline -> /data/dev-stuff/git-repos/tmux-powerline/powerline.sh
```

Without this change, the error you see when invoking the script using a symlink located elsewhere:



```
$ tmux-powerline left                                                                                                                                                                                                   
/home/ash/.local/bin/tmux-powerline: line 5: /home/ash/.local/bin/config/helpers.sh: No such file or directory                                                                                                          
/home/ash/.local/bin/tmux-powerline: line 6: /home/ash/.local/bin/config/paths.sh: No such file or directory                                                                                                            
/home/ash/.local/bin/tmux-powerline: line 7: /home/ash/.local/bin/config/shell.sh: No such file or directory                                                                                                            
/home/ash/.local/bin/tmux-powerline: line 8: /home/ash/.local/bin/config/defaults.sh: No such file or directory                                                                                                         
/home/ash/.local/bin/tmux-powerline: line 10: /arg_processing.sh: No such file or directory                                                                                                                             
/home/ash/.local/bin/tmux-powerline: line 11: /formatting.sh: No such file or directory                                                                                                                                 
/home/ash/.local/bin/tmux-powerline: line 12: /muting.sh: No such file or directory                                                                                                                                     
/home/ash/.local/bin/tmux-powerline: line 13: /powerline.sh: No such file or directory                                                                                                                                  
/home/ash/.local/bin/tmux-powerline: line 14: /rcfile.sh: No such file or directory                                                                                                                                     
/home/ash/.local/bin/tmux-powerline: line 16: powerline_muted: command not found                                                                                                                                        
/home/ash/.local/bin/tmux-powerline: line 17: process_settings: command not found                                                                                                                                       
/home/ash/.local/bin/tmux-powerline: line 18: check_arg_side: command not found                                                                                                                                         
/home/ash/.local/bin/tmux-powerline: line 22: print_powerline: command not found
```

This pull request fixes this issue by correctly determining the absolute path of the `powerline.sh` script, and using that to source other scripts when needed.