### PR TITLE
Add ability to selectively disable spacing and segment characters

### DIFF
--- a/lib/powerline.sh
+++ b/lib/powerline.sh
@@ -74,6 +74,8 @@ __process_segment_defaults() {
 			${input_segment[1]:-$TMUX_POWERLINE_DEFAULT_BACKGROUND_COLOR} \
 			${input_segment[2]:-$TMUX_POWERLINE_DEFAULT_FOREGROUND_COLOR} \
 			${input_segment[3]:-$default_separator} \
+			${input_segment[6]:-$spacing_disable} \
+			${input_segment[7]:-$separator_disable} \
 		)
 
 		powerline_segments[$segment_index]="${powerline_segment_with_defaults[@]}"
@@ -105,7 +107,15 @@ __process_scripts() {
 		fi
 
 		if [ -n "$output" ]; then
-			powerline_segment_contents[$segment_index]=" $output "
+			if [ ${powerline_segment[4]} == "L" ] ; then
+				powerline_segment_contents[$segment_index]="$output "
+			elif [ ${powerline_segment[4]} == "R" ] ; then
+				powerline_segment_contents[$segment_index]=" $output"
+			elif [ ${powerline_segment[4]} == "B" ] ; then
+				powerline_segment_contents[$segment_index]="$output"
+			else
+				powerline_segment_contents[$segment_index]=" $output "
+			fi
 		else
 			unset -v powerline_segments[$segment_index]
 		fi
@@ -115,6 +125,7 @@ __process_scripts() {
 __process_colors() {
 	for segment_index in "${!powerline_segments[@]}"; do
 		local powerline_segment=(${powerline_segments[$segment_index]})
+		local separator_enable=${powerline_segment[5]}
 		# Find the next segment that produces content (i.e. skip empty segments).
 		for next_segment_index in $(eval echo {$(($segment_index + 1))..${#powerline_segments}}) ; do
 			[[ -n ${powerline_segments[next_segment_index]} ]] && break
@@ -134,6 +145,7 @@ __process_colors() {
 		fi
 
 		local previous_background_color=${powerline_segment[1]}
+		powerline_segment[6]=$separator_enable
 
 		powerline_segments[$segment_index]="${powerline_segment[@]}"
 	done
@@ -148,8 +160,9 @@ __process_powerline() {
 		local separator=${powerline_segment[3]}
 		local separator_background_color=${powerline_segment[4]}
 		local separator_foreground_color=${powerline_segment[5]}
+		local separator_disable=${powerline_segment[6]}
 
-		eval "__print_${side}_segment \"${segment_index}\" \"${background_color}\" \"${foreground_color}\" \"${separator}\" \"${separator_background_color}\" \"${separator_foreground_color}\""
+		eval "__print_${side}_segment \"${segment_index}\" \"${background_color}\" \"${foreground_color}\" \"${separator}\" \"${separator_background_color}\" \"${separator_foreground_color}\" \"${separator_disable}\""
 	done
 }
 
@@ -160,9 +173,12 @@ __print_left_segment() {
 	local separator=$4
 	local separator_background_color=$5
 	local separator_foreground_color=$6
+	local separator_disable=$7
 
 	__print_colored_content "$content" "$content_background_color" "$content_foreground_color"
-	__print_colored_content "$separator" "$separator_background_color" "$separator_foreground_color"
+	if [ ! "$separator_disable" == "1" ] ; then
+		__print_colored_content "$separator" "$separator_background_color" "$separator_foreground_color"
+	fi
 }
 
 __print_right_segment() {
@@ -172,8 +188,11 @@ __print_right_segment() {
 	local separator=$4
 	local separator_background_color=$5
 	local separator_foreground_color=$6
+	local separator_disable=$7
 
-	__print_colored_content "$separator" "$separator_background_color" "$separator_foreground_color"
+	if [ ! "$separator_disable" == "1" ] ; then
+		__print_colored_content "$separator" "$separator_background_color" "$separator_foreground_color"
+	fi
 	__print_colored_content "$content" "$content_background_color" "$content_foreground_color"
 }
 

--- a/lib/powerline.sh
+++ b/lib/powerline.sh
@@ -107,11 +107,11 @@ __process_scripts() {
 		fi
 
 		if [ -n "$output" ]; then
-			if [ ${powerline_segment[4]} == "L" ] ; then
+			if [ ${powerline_segment[4]} == "left_disable" ] ; then
 				powerline_segment_contents[$segment_index]="$output "
-			elif [ ${powerline_segment[4]} == "R" ] ; then
+			elif [ ${powerline_segment[4]} == "right_disable" ] ; then
 				powerline_segment_contents[$segment_index]=" $output"
-			elif [ ${powerline_segment[4]} == "B" ] ; then
+			elif [ ${powerline_segment[4]} == "both_disable" ] ; then
 				powerline_segment_contents[$segment_index]="$output"
 			else
 				powerline_segment_contents[$segment_index]=" $output "
@@ -176,7 +176,7 @@ __print_left_segment() {
 	local separator_disable=$7
 
 	__print_colored_content "$content" "$content_background_color" "$content_foreground_color"
-	if [ ! "$separator_disable" == "1" ] ; then
+	if [ ! "$separator_disable" == "separator_disable" ] ; then
 		__print_colored_content "$separator" "$separator_background_color" "$separator_foreground_color"
 	fi
 }
@@ -190,7 +190,7 @@ __print_right_segment() {
 	local separator_foreground_color=$6
 	local separator_disable=$7
 
-	if [ ! "$separator_disable" == "1" ] ; then
+	if [ ! "$separator_disable" == "separator_disable" ] ; then
 		__print_colored_content "$separator" "$separator_background_color" "$separator_foreground_color"
 	fi
 	__print_colored_content "$content" "$content_background_color" "$content_foreground_color"

--- a/themes/default.sh
+++ b/themes/default.sh
@@ -48,7 +48,30 @@ if [ -z $TMUX_POWERLINE_WINDOW_STATUS_FORMAT ]; then
 	)
 fi
 
-# Format: segment_name background_color foreground_color [non_default_separator]
+# Format: segment_name background_color foreground_color [non_default_separator] [separator_background_color] [separator_foreground_color] [spacing_disable] [separator_disable]
+#
+# non_default_separator - specify an alternative character for this segment's separator
+# separator_background_color - specify a unique background color for the separator
+# separator_foreground_color - specify a unique foreground color for the separator
+# spacing_disable - remove space on left, right or both sides of the segment:
+#
+#   "left_disable" - disable space on the left
+#   "right_disable" - disable space on the right
+#   "both_disable" - disable spaces on both sides
+#   * - any other character/string produces no change to default behavior (eg "none", "X", etc.)
+#
+# separator_disable - disables drawing a separator on this segment, very useful for segments
+# with dynamic background colours (eg tmux_mem_cpu_load)
+#
+#   "separator_disable" - disables the separator
+#   * - any other character/string produces no change to default behavior
+#
+# Example segment with separator disabled and right space character disabled:
+# "hostname 33 0 {TMUX_POWERLINE_SEPARATOR_RIGHT_BOLD} 33 0 right_disable separator_disable"
+#
+# Note that although redundant the non_default_separator, separator_background_color and
+# separator_foreground_color options must still be specified so that appropriate index
+# of options to support the spacing_disable and separator_disable features can be used
 
 if [ -z $TMUX_POWERLINE_LEFT_STATUS_SEGMENTS ]; then
 	TMUX_POWERLINE_LEFT_STATUS_SEGMENTS=(


### PR DESCRIPTION
This commit allows you to specify additional segment options in your themes file to have more fine control over the rendering of specific segments in the status bar.  The goal was to allow a more seamless integration with the tmux-mem-cpu-load plugin so as to enable nesting it within other segments and still having the powerline look good.  Other custom statusbar plugins may also benefit from this feature.

R = Disk Free segment
G = Slightly modified tmux-mem-cpu-load segment
B = Battery segment

Before:
![before](https://user-images.githubusercontent.com/64343965/227733831-f63ce55e-2c32-4da7-933c-095f672b41b4.png)

After:
![after](https://user-images.githubusercontent.com/64343965/227733849-9eb54815-46bb-40c4-874e-cdfe53fcfc9f.png)

Note that the tmux-mem-cpu-load plugin in the screenshots has been modified to allow specification of the background colour in the memory section and to insert a trailing separator character in the load section so that dynamic colours seamlessly blend with the neighbouring segments.

This is an example of the adjustment required in the theme file:

![theme_file_changes](https://user-images.githubusercontent.com/64343965/227734255-97f10613-5aa8-4148-ac77-0d7b984d18b7.png)

The new options are not required to be set, so existing segment function is not impacted.  In the battery segment it was desirable for instance to not strip any leading or tailing whitespace but to only remove the separator at the start of the segment.  Thus an N was used (any character except L,R, or B) to ensure the conditions were not met to remove spacing.