### PR TITLE
Stop using realpath

### DIFF
--- a/generate_rc.sh
+++ b/generate_rc.sh
@@ -1,22 +1,7 @@
 #!/usr/bin/env bash
 # Generate default rc file.
 
-# macOS doesn't ship with realpath.
-# Bash implementation from https://stackoverflow.com/a/18443300/265508
-realpath() (
-  OURPWD=$PWD
-  cd "$(dirname "$1")"
-  LINK=$(readlink "$(basename "$1")")
-  while [ "$LINK" ]; do
-    cd "$(dirname "$LINK")"
-    LINK=$(readlink "$(basename "$1")")
-  done
-  REALPATH="$PWD/$(basename "$1")"
-  cd "$OURPWD"
-  echo "$REALPATH"
-)
-
-export TMUX_POWERLINE_DIR_HOME="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+export TMUX_POWERLINE_DIR_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "${TMUX_POWERLINE_DIR_HOME}/config/paths.sh"
 source "${TMUX_POWERLINE_DIR_HOME}/config/defaults.sh"

--- a/lib/headers.sh
+++ b/lib/headers.sh
@@ -1,22 +1,7 @@
 # Source all neede libs and helpers, kind of like a main.h.
 
-# macOS doesn't ship with realpath.
-# Bash implementation from https://stackoverflow.com/a/18443300/265508
-realpath() (
-  OURPWD=$PWD
-  cd "$(dirname "$1")"
-  LINK=$(readlink "$(basename "$1")")
-  while [ "$LINK" ]; do
-    cd "$(dirname "$LINK")"
-    LINK=$(readlink "$(basename "$1")")
-  done
-  REALPATH="$PWD/$(basename "$1")"
-  cd "$OURPWD"
-  echo "$REALPATH"
-)
-
 if [ -z "$TMUX_POWERLINE_DIR_HOME" ]; then
-	lib_dir="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+	lib_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 	export TMUX_POWERLINE_DIR_HOME="$(dirname "${lib_dir}")" # step up to parent dir.
 	unset lib_dir
 fi

--- a/mute_powerline.sh
+++ b/mute_powerline.sh
@@ -1,21 +1,6 @@
 #!/usr/bin/env bash
 
-# macOS doesn't ship with realpath.
-# Bash implementation from https://stackoverflow.com/a/18443300/265508
-realpath() (
-  OURPWD=$PWD
-  cd "$(dirname "$1")"
-  LINK=$(readlink "$(basename "$1")")
-  while [ "$LINK" ]; do
-    cd "$(dirname "$LINK")"
-    LINK=$(readlink "$(basename "$1")")
-  done
-  REALPATH="$PWD/$(basename "$1")"
-  cd "$OURPWD"
-  echo "$REALPATH"
-)
-
-export TMUX_POWERLINE_DIR_HOME="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+export TMUX_POWERLINE_DIR_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "${TMUX_POWERLINE_DIR_HOME}/config/paths.sh"
 source "${TMUX_POWERLINE_DIR_LIB}/muting.sh"

--- a/powerline.sh
+++ b/powerline.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-export TMUX_POWERLINE_DIR_HOME="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+export TMUX_POWERLINE_DIR_HOME="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source "${TMUX_POWERLINE_DIR_HOME}/lib/headers.sh"
 


### PR DESCRIPTION
as it's not always available.

I know using realpath was introduced in #281. However since then it became clear this is not working well on macOS as there's not realpath unless installed e.g. with Homebrew. Needing to have the shell implementation of realpath everywhere proved cumbersome. And since #281, this plugin is not supporting the manual installation anymore, tpm plugin is the way to go from now on.

Fixes #308
