### PR TITLE
fix(formatting.sh): return any non-abbreviated color as-is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow setting the `default` tmux color in segment themes. [#296](https://github.com/erikw/tmux-powerline/issues/296).
 ### Fixed
 - The now playing segment is fixed for Last.FM using their 2.0 API. [#307](https://github.com/erikw/tmux-powerline/issues/307)
+- Correctly handle named colours when specifying theme colours. [#314](https://github.com/erikw/tmux-powerline/issues/314)
 
 ## [2.1.0] - 2023-04-16
 ### Added
 - Config options to add keybindigns to mute the status bar added: `TMUX_POWERLINE_MUTE_LEFT_KEYBINDING` and `TMUX_POWERLINE_MUTE_RIGHT_KEYBINDING`.
 ### Changed
-- The old manual way is not supported for simplicity of maintaing the code.
+- The old manual way is not supported for simplicity of maintaining the code.
 
 ## [2.0.0] - 2023-04-15
 ### Added

--- a/lib/colors.sh
+++ b/lib/colors.sh
@@ -1,0 +1,31 @@
+# Utilities for working with colors
+#
+# Dependencies:
+#		- none
+
+#######################################
+# Accepts a single argument containing a color, returning a normalized color based
+# on the input
+#
+# If an integer between 1 and 3 characters long is provided, returns `colour[$1]`
+# otherwise returns the input unaltered
+#
+# Arguments:
+#   $1: The color to normalize
+#######################################
+__normalize_color() {
+	local input="$1"
+	local result
+
+	case "$input" in
+		[0-9]|[0-9][0-9]|[0-9][0-9][0-9]) # handle 1 to 3 digits
+			result="colour$input"
+			;;
+		*) # Catch-all
+			result=$input
+			;;
+	esac
+
+	echo -n "$result"
+}
+

--- a/lib/formatting.sh
+++ b/lib/formatting.sh
@@ -1,18 +1,3 @@
-__normalize_color() {
-	input="$1"
-	result
-
-	case "$input" in
-			[0-9]|[0-9][0-9]|[0-9][0-9][0-9]) # Convert 1 to 3 digit colours to 'colour[code]'
-					result="colour$input"
-					;;
-			*) # otherwise return whatever is passed
-					result=$input
-					;;
-	esac
-
-	echo -n "$result"
-}
 
 __print_colored_content() {
 	bgcolor=$(__normalize_color "$2")

--- a/lib/formatting.sh
+++ b/lib/formatting.sh
@@ -1,4 +1,16 @@
+# Utilities for formatting content
+#
+# Dependencies:
+#		- ./colors.sh
 
+#######################################
+# Returns a string coloring content using tmux's color formatting
+#
+# Arguments:
+#   $1: a string of text to render
+#   $2: the background color
+#   $3: the foreground color color
+#######################################
 __print_colored_content() {
 	bgcolor=$(__normalize_color "$2")
 	fgcolor=$(__normalize_color "$3")
@@ -7,4 +19,3 @@ __print_colored_content() {
 	echo -n "$1"
 	echo -n "#[default]"
 }
-

--- a/lib/formatting.sh
+++ b/lib/formatting.sh
@@ -1,19 +1,28 @@
-__print_colored_content() {
-	bgcolor="$2"
-	fgcolor="$3"
-	if [[ $bgcolor == "default" ]] ; then
-		  BGCOLOR=$bgcolor
-	else
-	[ "${bgcolor:0:1}" = "#" ] && BGCOLOR="$bgcolor" || BGCOLOR="colour$bgcolor"
-	fi
+__normalize_color() {
+	local input="$1"
+	local result
 
-	if [[ "$fgcolor" == "default" ]] ; then
-		FGCOLOR=$fgcolor
-	else
-	[ "${fgcolor:0:1}" = "#" ] && FGCOLOR="$fgcolor" || FGCOLOR="colour$fgcolor"
-	fi
+	case "$input" in
+			[0-9]|[0-9][0-9]|[0-9][0-9][0-9]) # Convert 1 to 3 digit colours to 'colour[code]'
+					result="colour$input"
+					;;
+			*) # otherwise return whatever is passed
+					result=$input
+					;;
+	esac
 
-	 echo -n "#[fg=${FGCOLOR},bg=${BGCOLOR}]"
-	 echo -n "$1"
-	 echo -n "#[default]"
+	echo -n "$result"
 }
+
+__print_colored_content() {
+	local bgcolor
+	local fgcolor
+
+	bgcolor=$(__normalize_color "$2")
+	fgcolor=$(__normalize_color "$3")
+
+	echo -n "#[fg=${fgcolor},bg=${bgcolor}]"
+	echo -n "$1"
+	echo -n "#[default]"
+}
+

--- a/lib/formatting.sh
+++ b/lib/formatting.sh
@@ -1,6 +1,6 @@
 __normalize_color() {
-	local input="$1"
-	local result
+	input="$1"
+	result
 
 	case "$input" in
 			[0-9]|[0-9][0-9]|[0-9][0-9][0-9]) # Convert 1 to 3 digit colours to 'colour[code]'
@@ -15,9 +15,6 @@ __normalize_color() {
 }
 
 __print_colored_content() {
-	local bgcolor
-	local fgcolor
-
 	bgcolor=$(__normalize_color "$2")
 	fgcolor=$(__normalize_color "$3")
 

--- a/lib/headers.sh
+++ b/lib/headers.sh
@@ -1,6 +1,6 @@
 # Source all needed libs and helpers, kind of like a main.h.
 
-if [ "$TMUX_POWERLINE_DIR_HOME" = "" ]; then
+if [ -z "$TMUX_POWERLINE_DIR_HOME" ]; then
 	lib_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 	TMUX_POWERLINE_DIR_HOME="$(dirname "$lib_dir")" # step up to parent dir.
 

--- a/lib/headers.sh
+++ b/lib/headers.sh
@@ -11,6 +11,7 @@ source "${TMUX_POWERLINE_DIR_HOME}/config/paths.sh"
 source "${TMUX_POWERLINE_DIR_HOME}/config/shell.sh"
 source "${TMUX_POWERLINE_DIR_HOME}/config/defaults.sh"
 
+source "${TMUX_POWERLINE_DIR_LIB}/colors.sh"
 source "${TMUX_POWERLINE_DIR_LIB}/arg_processing.sh"
 source "${TMUX_POWERLINE_DIR_LIB}/formatting.sh"
 source "${TMUX_POWERLINE_DIR_LIB}/muting.sh"

--- a/lib/headers.sh
+++ b/lib/headers.sh
@@ -1,8 +1,10 @@
-# Source all neede libs and helpers, kind of like a main.h.
+# Source all needed libs and helpers, kind of like a main.h.
 
-if [ -z "$TMUX_POWERLINE_DIR_HOME" ]; then
+if [ "$TMUX_POWERLINE_DIR_HOME" = "" ]; then
 	lib_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-	export TMUX_POWERLINE_DIR_HOME="$(dirname "${lib_dir}")" # step up to parent dir.
+	TMUX_POWERLINE_DIR_HOME="$(dirname "$lib_dir")" # step up to parent dir.
+
+	export TMUX_POWERLINE_DIR_HOME
 	unset lib_dir
 fi
 

--- a/lib/powerline.sh
+++ b/lib/powerline.sh
@@ -2,7 +2,9 @@
 
 print_powerline() {
 	local side="$1"
-	local upper_side=$(echo "$1" | tr '[:lower:]' '[:upper:]')
+	local upper_side
+
+	upper_side=$(echo "$1" | tr '[:lower:]' '[:upper:]')
 	eval "local input_segments=(\"\${TMUX_POWERLINE_${upper_side}_STATUS_SEGMENTS[@]}\")"
 	local powerline_segments=()
 	local powerline_segment_contents=()
@@ -38,7 +40,7 @@ format() {
 
 # Prettifies the window-status segments.
 init_powerline() {
-	if [ -z $TMUX_POWERLINE_WINDOW_STATUS_CURRENT ]; then
+	if [ -z "$TMUX_POWERLINE_WINDOW_STATUS_CURRENT" ]; then
 		TMUX_POWERLINE_WINDOW_STATUS_CURRENT=(
 			"#[$(format inverse)]" \
 			"$TMUX_POWERLINE_DEFAULT_LEFTSIDE_SEPARATOR" \
@@ -50,13 +52,13 @@ init_powerline() {
 		)
 	fi
 
-	if [ -z $TMUX_POWERLINE_WINDOW_STATUS_STYLE ]; then
+	if [ -z "$TMUX_POWERLINE_WINDOW_STATUS_STYLE" ]; then
 		TMUX_POWERLINE_WINDOW_STATUS_STYLE=(
 			"$(format regular)"
 		)
 	fi
 
-	if [ -z $TMUX_POWERLINE_WINDOW_STATUS_FORMAT ]; then
+	if [ -z "$TMUX_POWERLINE_WINDOW_STATUS_FORMAT" ]; then
 		TMUX_POWERLINE_WINDOW_STATUS_FORMAT=(
 			"#[$(format regular)]" \
 			"  #I#{?window_flags,#F, } " \
@@ -79,7 +81,7 @@ init_powerline() {
 
 __process_segment_defaults() {
 	for segment_index in "${!input_segments[@]}"; do
-		local input_segment=(${input_segments[$segment_index]})
+		local input_segment=(${input_segments[segment_index]})
 		eval "local default_separator=\$TMUX_POWERLINE_DEFAULT_${upper_side}SIDE_SEPARATOR"
 
 		powerline_segment_with_defaults=(
@@ -91,13 +93,13 @@ __process_segment_defaults() {
 			${input_segment[7]:-$separator_disable} \
 		)
 
-		powerline_segments[$segment_index]="${powerline_segment_with_defaults[@]}"
+		powerline_segments[segment_index]="${powerline_segment_with_defaults[@]}"
 	done
 }
 
 __process_scripts() {
 	for segment_index in "${!powerline_segments[@]}"; do
-		local powerline_segment=(${powerline_segments[$segment_index]})
+		local powerline_segment=(${powerline_segments[segment_index]})
 
 		if [ -n "$TMUX_POWERLINE_DIR_USER_SEGMENTS" ] && [ -f "$TMUX_POWERLINE_DIR_USER_SEGMENTS/${powerline_segment[0]}.sh" ] ; then
 			local script="$TMUX_POWERLINE_DIR_USER_SEGMENTS/${powerline_segment[0]}.sh"
@@ -121,33 +123,33 @@ __process_scripts() {
 
 		if [ -n "$output" ]; then
 			if [[ ${powerline_segment[4]} == "left_disable" ]]; then
-				powerline_segment_contents[$segment_index]="$output "
+				powerline_segment_contents[segment_index]="$output "
 			elif [[ ${powerline_segment[4]} == "right_disable" ]]; then
-				powerline_segment_contents[$segment_index]=" $output"
+				powerline_segment_contents[segment_index]=" $output"
 			elif [[ ${powerline_segment[4]} == "both_disable" ]]; then
-				powerline_segment_contents[$segment_index]="$output"
+				powerline_segment_contents[segment_index]="$output"
 			else
-				powerline_segment_contents[$segment_index]=" $output "
+				powerline_segment_contents[segment_index]=" $output "
 			fi
 		else
-			unset -v powerline_segments[$segment_index]
+			unset -v powerline_segments[segment_index]
 		fi
 	done
 }
 
 __process_colors() {
 	for segment_index in "${!powerline_segments[@]}"; do
-		local powerline_segment=(${powerline_segments[$segment_index]})
+		local powerline_segment=(${powerline_segments[segment_index]})
 		local separator_enable=${powerline_segment[5]}
 		# Find the next segment that produces content (i.e. skip empty segments).
-		for next_segment_index in $(eval echo {$(($segment_index + 1))..${#powerline_segments}}) ; do
+		for next_segment_index in $(eval echo "{$((segment_index + 1))..${#powerline_segments}}") ; do
 			[[ -n ${powerline_segments[next_segment_index]} ]] && break
 		done
-		local next_segment=(${powerline_segments[$next_segment_index]})
+		local next_segment=(${powerline_segments[next_segment_index]})
 
-		if [ $side == 'left' ]; then
+		if [ "$side" == 'left' ]; then
 			powerline_segment[4]=${next_segment[1]:-$TMUX_POWERLINE_DEFAULT_BACKGROUND_COLOR}
-		elif [ $side == 'right' ]; then
+		elif [ "$side" == 'right' ]; then
 			powerline_segment[4]=${previous_background_color:-$TMUX_POWERLINE_DEFAULT_BACKGROUND_COLOR}
 		fi
 
@@ -160,13 +162,13 @@ __process_colors() {
 		local previous_background_color=${powerline_segment[1]}
 		powerline_segment[6]=$separator_enable
 
-		powerline_segments[$segment_index]="${powerline_segment[@]}"
+		powerline_segments[segment_index]="${powerline_segment[@]}"
 	done
 }
 
 __process_powerline() {
 	for segment_index in "${!powerline_segments[@]}"; do
-		local powerline_segment=(${powerline_segments[$segment_index]})
+		local powerline_segment=(${powerline_segments[segment_index]})
 
 		local background_color=${powerline_segment[1]}
 		local foreground_color=${powerline_segment[2]}
@@ -210,8 +212,8 @@ __print_right_segment() {
 }
 
 __segment_separator_is_thin() {
-	[[ ${powerline_segment[3]} == $TMUX_POWERLINE_SEPARATOR_LEFT_THIN || \
-		${powerline_segment[3]} == $TMUX_POWERLINE_SEPARATOR_RIGHT_THIN ]];
+	[[ ${powerline_segment[3]} == "$TMUX_POWERLINE_SEPARATOR_LEFT_THIN" || \
+		${powerline_segment[3]} == "$TMUX_POWERLINE_SEPARATOR_RIGHT_THIN" ]];
 }
 
 __check_platform() {
@@ -219,3 +221,4 @@ __check_platform() {
 		 echo "Unknown platform; modify config/shell.sh"  &1>&2
 	fi
 }
+

--- a/lib/powerline.sh
+++ b/lib/powerline.sh
@@ -17,18 +17,23 @@ print_powerline() {
 }
 
 format() {
-    local type="$1"
+	local type="$1"
+	local bg_color
+	local fg_color
 
-    case $type in
-	inverse)
-		echo "fg=colour$TMUX_POWERLINE_DEFAULT_BACKGROUND_COLOR,bg=colour$TMUX_POWERLINE_DEFAULT_FOREGROUND_COLOR,nobold,noitalics,nounderscore"
-		;;
-	regular)
-		echo "fg=colour$TMUX_POWERLINE_DEFAULT_FOREGROUND_COLOR,bg=colour$TMUX_POWERLINE_DEFAULT_BACKGROUND_COLOR,nobold,noitalics,nounderscore"
-		;;
-	*)
-		;;
-    esac
+	bg_color=$(__normalize_color "$TMUX_POWERLINE_DEFAULT_BACKGROUND_COLOR")
+	fg_color=$(__normalize_color "$TMUX_POWERLINE_DEFAULT_FOREGROUND_COLOR")
+
+	case $type in
+		inverse)
+			echo "fg=$bg_color,bg=$fg_color,nobold,noitalics,nounderscore"
+			;;
+		regular)
+			echo "fg=$fg_color,bg=$bg_color,nobold,noitalics,nounderscore"
+			;;
+		*)
+			;;
+	esac
 }
 
 # Prettifies the window-status segments.
@@ -60,10 +65,16 @@ init_powerline() {
 		)
 	fi
 
+	local bg_color
+	local fg_color
+
+	bg_color=$(__normalize_color "$TMUX_POWERLINE_DEFAULT_BACKGROUND_COLOR")
+	fg_color=$(__normalize_color "$TMUX_POWERLINE_DEFAULT_FOREGROUND_COLOR")
+
 	tmux set-option -g window-status-current-format "$(printf '%s' "${TMUX_POWERLINE_WINDOW_STATUS_CURRENT[@]}")"
 	tmux set-option -g window-status-format "$(printf '%s' "${TMUX_POWERLINE_WINDOW_STATUS_FORMAT[@]}")"
 	tmux set-option -g window-status-style "$(printf '%s' "${TMUX_POWERLINE_WINDOW_STATUS_STYLE[@]}")"
-	tmux set-option -g status-style "fg=colour$TMUX_POWERLINE_DEFAULT_FOREGROUND_COLOR,bg=colour$TMUX_POWERLINE_DEFAULT_BACKGROUND_COLOR"
+	tmux set-option -g status-style "fg=$fg_color,bg=$bg_color"
 }
 
 __process_segment_defaults() {


### PR DESCRIPTION
Allows for using named valid colours when theming `tmux-powerline`, e.g. `red`, `color123`, `colour123`, `default`, in addition to converting abbreviated colour values to their `colo[u]r` variants

closes #314