### PR TITLE
Remove extra S from custom segments section

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ In the same was as themes, you can create your own segments at `TMUX_POWERLINE_D
 
 To get started, copy an existing segment that is similar to the segment that you want to create.
 ```shell
-mkdir -p ~/.config/tmux-powerline/segmentss
+mkdir -p ~/.config/tmux-powerline/segments
 cp ~/.config/tmux/plugins/tmux-powerline/segments/date.sh ~/.config/tmux-powerline/themes/my-segment.sh
 $EDITOR ~/.config/tmux-powerline/themes/my-segment.sh.default
 ```


### PR DESCRIPTION
## Summary
- Removing extra "s" character from `Custom Segments` in README

## Test Plan
Markdown renders without typo
<img width="971" alt="image" src="https://github.com/erikw/tmux-powerline/assets/29241719/cecab743-bb68-4068-9823-04dcdd188209">
