### PR TITLE
Alternated Battery Status Condition Check in Bash

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -37,3 +37,4 @@ MSempere
 kurczynski
 Alejandro Espinosa (Halbard) <alejosp493@gmail.com>
 TN Khanh <tnkhanh4@gmail.com>
+Skywarth <yigitk.ersoy@gmail.com>

--- a/segments/battery.sh
+++ b/segments/battery.sh
@@ -97,7 +97,7 @@ __battery_osx() {
 					BAT_NOW=$BATPATH/energy_now
 				fi
 
-				if [ "$1" = `cat $STATUS` -o "$1" = "" ]; then
+				if [[ "$1" = `cat $STATUS` || "$1" = "" ]]; then
 					__linux_get_bat
 				fi
 				;;


### PR DESCRIPTION
### Overview
This PR addresses an issue with the battery status condition check in the Bash function. Under certain conditions, particularly when the input parameter was an empty string, the previous condition regarding comparison to `cat $STATUS` using `[ ... ]` could become malformed.

**I can develop some additional conditions and checks for compatibility with POSIX-compliant shells if it's a target platform.**

### Linked issue/bug report

Please see #331 for additional details on the bug and findings.

### Changes
- Switched to using the `[[ ... ]]` test construct for the battery status check. This provides a more robust and predictable behavior in Bash.


### Impact
- Users with Bash as their shell will experience a more reliable battery status check.
- This change is Bash-specific and may not be portable to strictly POSIX-compliant shells.
- Be wary that it could break compatibility with other shell variants such as `sh`, `ash`, `dash` perhaps. Haven't tested it in those shells.

### Testing
The changes have been tested on a default Ubuntu 22.04 installation with no shell customization. Only tmux, tpm and tmux-powerline is installed for terminal. 

Please review and let me know if there are any concerns or feedback.
