### PR TITLE
add segment for gcalcli

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -38,3 +38,4 @@ kurczynski
 Alejandro Espinosa (Halbard) <alejosp493@gmail.com>
 TN Khanh <tnkhanh4@gmail.com>
 Skywarth <yigitk.ersoy@gmail.com>
+Drew Daniels <daniels_drew@protonmail.com>

--- a/segments/gcalcli.sh
+++ b/segments/gcalcli.sh
@@ -1,0 +1,32 @@
+# Print next Google Calendar Event
+
+TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME_DEFAULT=1
+
+generate_segmentrc() {
+	read -d '' rccontents  << EORC
+gcalcli uses military time by default - if you want to see 12 hour time format, set TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME_DEFAULT to 0
+export TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME="${TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME_DEFAULT}"
+EORC
+	echo "$rccontents"
+}
+
+__process_settings() {
+	if [ -z "$TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME" ]; then
+		export TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME="${TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME_DEFAULT}"
+	fi
+}
+
+run_segment() {
+  if ! command -v gcalcli &> /dev/null
+  then
+    echo "'gcalcli' could not be found"
+    return 1
+  fi
+  __process_settings
+  gcmd=(gcalcli agenda)
+  if [[ $TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME == 0 ]]; then
+    gcmd+=(--no-military)
+  fi
+  "${gcmd[@]}" | head -2 | tail -1 | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' | sed -E 's/ +/ /g'
+	return 0
+}

--- a/segments/gcalcli.sh
+++ b/segments/gcalcli.sh
@@ -1,18 +1,18 @@
 # Print next Google Calendar Event
 
-TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME_DEFAULT=1
+TMUX_POWERLINE_SEG_GCALCLI_24HR_TIME_FORMAT_DEFAULT=1
 
 generate_segmentrc() {
 	read -d '' rccontents  << EORC
-gcalcli uses military time by default - if you want to see 12 hour time format, set TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME_DEFAULT to 0
-export TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME="${TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME_DEFAULT}"
+# gcalcli uses 24hr time format by default - if you want to see 12hr time format, set TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME_DEFAULT to 0
+export TMUX_POWERLINE_SEG_GCALCLI_24HR_TIME_FORMAT="${TMUX_POWERLINE_SEG_GCALCLI_24HR_TIME_FORMAT_DEFAULT}"
 EORC
 	echo "$rccontents"
 }
 
 __process_settings() {
-	if [ -z "$TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME" ]; then
-		export TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME="${TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME_DEFAULT}"
+	if [ -z "$TMUX_POWERLINE_SEG_GCALCLI_24HR_TIME_FORMAT" ]; then
+		export TMUX_POWERLINE_SEG_GCALCLI_24HR_TIME_FORMAT="${TMUX_POWERLINE_SEG_GCALCLI_24HR_TIME_FORMAT_DEFAULT}"
 	fi
 }
 
@@ -24,7 +24,7 @@ run_segment() {
   fi
   __process_settings
   gcmd=(gcalcli agenda)
-  if [[ $TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME == 0 ]]; then
+  if [[ $TMUX_POWERLINE_SEG_GCALCLI_24HR_TIME_FORMAT == 0 ]]; then
     gcmd+=(--no-military)
   fi
   "${gcmd[@]}" | head -2 | tail -1 | sed 's/\x1B\[[0-9;]\{1,\}[A-Za-z]//g' | sed -E 's/ +/ /g'


### PR DESCRIPTION
I've been using the [gcalcli](https://github.com/insanum/gcalcli) tool since yesterday, which allows you to perform basic Google Calendar actions from your command line, and they had a [recommendation](https://github.com/insanum/gcalcli#agenda-integration-with-tmux) on how you could use the output from running `gcalcli agenda | head -2 | tail -1` to print your next Google Calendar event on your `tmux` status line:

![image](https://github.com/erikw/tmux-powerline/assets/62859552/177f6121-52d5-4886-a798-c0bd71592cbb)

I thought this was pretty cool, and hacked something together to display the output from this command as a `tmux-powerline` segment. The main updates I've made are:
- Adding a `TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME` option so users can opt out of using military time. 
  - When 0, the `--no-military-time` option will be provided to `gcalcli`
  - When 1 (Default), the `--no-military-time` option _will not_ be provided to `gcalcli`
- Stripping all color coding information from the standard output of `gcalcli agenda`, which usually looks like this:

![image](https://github.com/erikw/tmux-powerline/assets/62859552/210d0e05-4647-495c-b695-e0015ad5396b)

- Stripping extra whitespace from the output so that it does not unnecessarily take up more space than necessary to display events.

This would be my first open source contribution so if there's anything I've missed, please let me know! But thought other people might get some use out of this.

Here's what it looks like without any fancy text/background colors:

`TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME == 1` (Default)

![image](https://github.com/erikw/tmux-powerline/assets/62859552/c41c484a-57ff-4929-8845-78b1c085f0a5)

`TMUX_POWERLINE_SEG_GCALCLI_MILITARY_TIME == 0`

![image](https://github.com/erikw/tmux-powerline/assets/62859552/78fee176-4be8-479a-b5f3-029af22f88ab)
