### PR TITLE
Select a better NIC for the segments `lan_ip` and `ifstat_sys` with multiple NICs

### DIFF
--- a/segments/ifstat_sys.sh
+++ b/segments/ifstat_sys.sh
@@ -4,7 +4,10 @@
 run_segment() {
 	sleeptime="0.5"
 	if shell_is_osx; then
-		iface="en0"
+		iface=$(route get default | grep -i interface | awk '{print $2}')
+		if [ -z "$iface" ]; then
+			iface="en0"
+		fi
 		type="⎆" # "☫" for wlan
 		RXB=$(netstat -i -b | grep -m 1 $iface | awk '{print $7}')
 		TXB=$(netstat -i -b | grep -m 1 $iface | awk '{print $10}')
@@ -12,7 +15,10 @@ run_segment() {
 		RXBN=$(netstat -i -b | grep -m 1 $iface | awk '{print $7}')
 		TXBN=$(netstat -i -b | grep -m 1 $iface | awk '{print $10}')
 	else
-		iface=$(/bin/cat /proc/net/dev | /usr/bin/awk '{if($2>0 && NR > 2) print substr($1, 0, index($1, ":") - 1)}' | /bin/sed '/^lo$/d')
+		iface=$(ip route get 1.1.1.1 | grep -o "dev.*" | cut -d ' ' -f 2)
+		if [ -z "$iface" ]; then
+			iface=$(/bin/cat /proc/net/dev | /usr/bin/awk '{if($2>0 && NR > 2) print substr($1, 0, index($1, ":") - 1)}' | /bin/sed '/^lo$/d')
+		fi
 		type="⎆" # "☫" for wlan
 		RXB=$(</sys/class/net/"$iface"/statistics/rx_bytes)
 		TXB=$(</sys/class/net/"$iface"/statistics/tx_bytes)

--- a/segments/ifstat_sys.sh
+++ b/segments/ifstat_sys.sh
@@ -17,7 +17,7 @@ run_segment() {
 	else
 		iface=$(ip route show default | grep -o "dev.*" | cut -d ' ' -f 2)
 		if [ -z "$iface" ]; then
-			iface=$(/bin/cat /proc/net/dev | /usr/bin/awk '{if($2>0 && NR > 2) print substr($1, 0, index($1, ":") - 1)}' | /bin/sed '/^lo$/d')
+			iface=$(cat /proc/net/dev | awk '{if($2>0 && NR > 2) print substr($1, 0, index($1, ":") - 1)}' | sed '/^lo$/d')
 		fi
 		type="⎆" # "☫" for wlan
 		RXB=$(</sys/class/net/"$iface"/statistics/rx_bytes)

--- a/segments/ifstat_sys.sh
+++ b/segments/ifstat_sys.sh
@@ -15,7 +15,7 @@ run_segment() {
 		RXBN=$(netstat -i -b | grep -m 1 $iface | awk '{print $7}')
 		TXBN=$(netstat -i -b | grep -m 1 $iface | awk '{print $10}')
 	else
-		iface=$(ip route get 1.1.1.1 | grep -o "dev.*" | cut -d ' ' -f 2)
+		iface=$(ip route show default | grep -o "dev.*" | cut -d ' ' -f 2)
 		if [ -z "$iface" ]; then
 			iface=$(/bin/cat /proc/net/dev | /usr/bin/awk '{if($2>0 && NR > 2) print substr($1, 0, index($1, ":") - 1)}' | /bin/sed '/^lo$/d')
 		fi

--- a/segments/lan_ip.sh
+++ b/segments/lan_ip.sh
@@ -2,8 +2,11 @@
 
 run_segment() {
 	if shell_is_bsd || shell_is_osx ; then
+		default_route_nic=$(route get default | grep -i interface | awk '{print $2}')
 		all_nics=$(ifconfig 2>/dev/null | awk -F':' '/^[a-z]/ && !/^lo/ { print $1 }' | tr '\n' ' ')
 		IFS=' ' read -ra all_nics_array <<< "$all_nics"
+		# the nic of the default route is considered first
+		all_nics_array=("$default_route_nic" "${all_nics_array[@]}")
 		for nic in "${all_nics_array[@]}"; do
 			ipv4s_on_nic=$(ifconfig ${nic} 2>/dev/null | awk '$1 == "inet" { print $2 }')
 			for lan_ip in ${ipv4s_on_nic[@]}; do

--- a/segments/lan_ip.sh
+++ b/segments/lan_ip.sh
@@ -15,9 +15,12 @@ run_segment() {
 			[[ -n "${lan_ip}" ]] && break
 		done
 	else
+		default_route_nic=$(ip route get 1.1.1.1 | grep -o "dev.*" | cut -d ' ' -f 2)
 		# Get the names of all attached NICs.
 		all_nics="$(ip addr show | cut -d ' ' -f2 | tr -d :)"
 		all_nics=(${all_nics[@]/lo/})	 # Remove lo interface.
+		# the nic of the default route is considered first
+		all_nics=("$default_route_nic" "${all_nics[@]}")
 
 		for nic in "${all_nics[@]}"; do
 			# Parse IP address for the NIC.


### PR DESCRIPTION
With multiple NICs (and thus lan ips), the NIC that transmits traffic heading for the Internet (i.e., the NIC connected to the gateway) should be considered first.

This pull request obtains the target NIC by querying the default route. If obtained, the NIC is considered first for displaying lan ip and monitoring network bandwidth.