### PR TITLE
Look for `tmux-cpu-mem-load` from `tpm`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,3 +39,4 @@ Alejandro Espinosa (Halbard) <alejosp493@gmail.com>
 TN Khanh <tnkhanh4@gmail.com>
 Skywarth <yigitk.ersoy@gmail.com>
 Drew Daniels <daniels_drew@protonmail.com>
+Danfeng Shan <shandanf@gmail.com>

--- a/segments/tmux_mem_cpu_load.sh
+++ b/segments/tmux_mem_cpu_load.sh
@@ -1,12 +1,15 @@
 # Print out Memory, cpu and load using https://github.com/thewtex/tmux-mem-cpu-load
 
 run_segment() {
-	type tmux-mem-cpu-load >/dev/null 2>&1
-	if [ "$?" -ne 0 ]; then
+	stats=""
+	if type $TMUX_PLUGIN_MANAGER_PATH/tmux-mem-cpu-load/tmux-mem-cpu-load > /dev/null 2>&1; then
+		stats=$($TMUX_PLUGIN_MANAGER_PATH/tmux-mem-cpu-load/tmux-mem-cpu-load)
+	elif type tmux-mem-cpu-load >/dev/null 2>&1; then
+		stats=$(tmux-mem-cpu-load)
+	else
 		return
 	fi
 
-	stats=$(tmux-mem-cpu-load)
 	if [ -n "$stats" ]; then
 		echo "$stats";
 	fi


### PR DESCRIPTION
The `tmux-cpu-mem-load` segment only searches the `tmux-cpu-mem-load` command from the `$PATH`.
However, some users may prefer to install `tmux-cpu-mem-load` through `tpm`, by which the command is not in the `$PATH` and this segment fails.

This pull request tries to fix this by looking for `tmux-mem-cpu-load` from the `tpm` first.