### PR TITLE
fix: Quote path variables and avoid `-o`/`-a` flags to `[`

### DIFF
--- a/config/helpers.sh
+++ b/config/helpers.sh
@@ -1,9 +1,9 @@
 # Other settings and helper functions.
 
 debug_mode_enabled() {
-	[ -n "$TMUX_POWERLINE_DEBUG_MODE_ENABLED" -a "$TMUX_POWERLINE_DEBUG_MODE_ENABLED" != "false" ];
+	[ -n "$TMUX_POWERLINE_DEBUG_MODE_ENABLED" ] && [ "$TMUX_POWERLINE_DEBUG_MODE_ENABLED" != "false" ];
 }
 
 patched_font_in_use() {
-	[ -z "$TMUX_POWERLINE_PATCHED_FONT_IN_USE" -o "$TMUX_POWERLINE_PATCHED_FONT_IN_USE" != "false" ];
+	[ -z "$TMUX_POWERLINE_PATCHED_FONT_IN_USE" ] || [ "$TMUX_POWERLINE_PATCHED_FONT_IN_USE" != "false" ];
 }

--- a/lib/arg_processing.sh
+++ b/lib/arg_processing.sh
@@ -2,7 +2,7 @@
 
 check_arg_side() {
 	local side="$1"
-	if ! [ "$side" ==  "left" -o "$side" == "right" -o "$side" == "init" ]; then
+	if ! [[ "$side" ==  "left" || "$side" == "right" || "$side" == "init" ]]; then
 		echo "Argument must be the side to handle {left, right} or {init} and not \"${side}\"."
     	exit 1
 	fi

--- a/lib/muting.sh
+++ b/lib/muting.sh
@@ -2,14 +2,14 @@
 # In all cases $1 is the side to be muted (eg left/right).
 
 powerline_muted() {
-	[ -e "$(__powerline_mute_file $1)" ];
+	[ -e "$(__powerline_mute_file "$1")" ];
 }
 
 toggle_powerline_mute_status() {
-	if powerline_muted $1; then
-		rm "$(__powerline_mute_file $1)"
+	if powerline_muted "$1"; then
+		rm "$(__powerline_mute_file "$1")"
 	else
-		touch "$(__powerline_mute_file $1)"
+		touch "$(__powerline_mute_file "$1")"
 	fi
 }
 


### PR DESCRIPTION
This fixes a bug in which paths (which could contain whitespace) were not properly quoted. This also avoids using [certain test flags](https://www.shellcheck.net/wiki/SC2166) due to their ambiguity in some cases.