### PR TITLE
Remove noisy air segment logs during `generate_rc.sh`

### DIFF
--- a/segments/air_color.sh
+++ b/segments/air_color.sh
@@ -1,10 +1,8 @@
 TMUX_POWERLINE_DIR_TEMPORARY="/tmp/tmux-powerline_${USER}"
 air_temp_file="${TMUX_POWERLINE_DIR_TEMPORARY}/temp_air_file.txt"
 
-if [ -n $air_temp_file ]; then
-    TMUX_POWERLINE_SEG_AIR_COLOR=$(awk '{print $NF}' $air_temp_file)
+if [ -n "$air_temp_file" ] && [ -f "$air_temp_file" ]; then
+    TMUX_POWERLINE_SEG_AIR_COLOR=$(awk '{print $NF}' "$air_temp_file")
 fi
 
 TMUX_POWERLINE_SEG_AIR_COLOR="${TMUX_POWERLINE_SEG_AIR_COLOR:-'37'}"
-
-echo "$TMUX_POWERLINE_SEG_AIR_COLOR"


### PR DESCRIPTION
These changes were added in this [pull request](https://github.com/erikw/tmux-powerline/pull/354/files). Two quick fixes:
- Add check that `$air_temp_file` exists. If it doesn't, `awk` complains; see screenshot below.
- Remove unnecessary `echo`. 

![image](https://github.com/erikw/tmux-powerline/assets/7005546/b529b52b-b8db-4922-9a02-b188e3b940d6)

### Testing
Verified that `.generate_rc.sh` runs without noisy logs after changes.

![image](https://github.com/erikw/tmux-powerline/assets/7005546/16855a02-bd54-471d-869c-c0113111deba)
