### PR TITLE
Update mode indicator segment for modern usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Some examples of segments available that you can add to your tmux status bar are
 * Date and time
 * Hostname
 * tmux info
-# tmux mode indicator (normal/prefix, mouse, copy modes)
+* tmux mode indicator (normal/prefix, mouse, copy modes)
 * CWD in pane
 * Current X keyboard layout
 * Network download/upload speed

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Some examples of segments available that you can add to your tmux status bar are
 * Date and time
 * Hostname
 * tmux info
+# tmux mode indicator (normal/prefix, mouse, copy modes)
 * CWD in pane
 * Current X keyboard layout
 * Network download/upload speed

--- a/lib/powerline.sh
+++ b/lib/powerline.sh
@@ -95,8 +95,8 @@ __process_scripts() {
 			local script="$TMUX_POWERLINE_DIR_SEGMENTS/${powerline_segment[0]}.sh"
 		fi
 
-		export TMUX_POWERLINE_CUR_SEGMENT_BG="${powerline_segment[1]}"
-		export TMUX_POWERLINE_CUR_SEGMENT_FG="${powerline_segment[2]}"
+		export TMUX_POWERLINE_CUR_SEGMENT_BG=$(__normalize_color "${powerline_segment[1]}")
+		export TMUX_POWERLINE_CUR_SEGMENT_FG=$(__normalize_color "${powerline_segment[2]}")
 		source "$script"
 		local output
 		output=$(run_segment)

--- a/segments/mode_indicator.sh
+++ b/segments/mode_indicator.sh
@@ -1,19 +1,196 @@
-# Indicator of pressing TMUX prefix, copy and insert modes.
+# Segment that indicates status of various tmux modes. The list of supported
+# modes & a brief description of each is as follows:
+#
+# - Normal mode: The default mode when you are simply using tmux.
+#
+# - Prefix mode: The mode when the tmux prefix key is pressed.
+#
+# - Mouse mode: While not definitionally a mode according to `man tmux`, this is
+#   a mode in the sense that it changes the behavior of tmux, & can be toggled
+#   on & off via the `tmux set-option -g mouse {on,off}` command; see `man tmux`
+#   for more details.
+#
+# - Copy mode: The mode when text is being copied. By default this is triggered
+#   by pressing the prefix key followed by '['; see `man tmux` for more details.
+#
+# Normal & prefix modes toggle between each other, so they occupy the same
+# section of this segment. The other modes are independent of each other, so
+# they each have their own part of the segment. By default, all modes are
+# enabled, the text color for each node defaults to whatever foreground color is
+# set in the user's theme, & the below list defines the default text for each
+# mode & separator. These can all be overridden in `config.sh`.
 
-prefix_pressed_text="PREFIX PRESSED"
-insert_mode_text="INSERT"
-copy_mode_text="COPY"
-normal_mode_text="NORMAL"
-separator="✤"
+# Default values for the settings that this segment supports.
+NORMAL_AND_PREFIX_MODE_ENABLED_DEFAULT="true"
 
-prefix_mode_fg="colour226"
-normal_mode_fg="colour16"
-copy_mode_fg="colour82"
-bg="colour33"
+NORMAL_MODE_TEXT_DEFAULT="normal"
+NORMAL_MODE_TEXT_COLOR_DEFAULT="$TMUX_POWERLINE_CUR_SEGMENT_FG"
+
+PREFIX_MODE_TEXT_DEFAULT="prefix"
+PREFIX_MODE_TEXT_COLOR_DEFAULT="$TMUX_POWERLINE_CUR_SEGMENT_FG"
+
+MOUSE_MODE_ENABLED_DEFAULT="true"
+
+MOUSE_MODE_TEXT_DEFAULT="mouse"
+MOUSE_MODE_TEXT_COLOR_DEFAULT="$TMUX_POWERLINE_CUR_SEGMENT_FG"
+
+COPY_MODE_ENABLED_DEFAULT="true"
+
+COPY_MODE_TEXT_DEFAULT="copy"
+COPY_MODE_TEXT_COLOR_DEFAULT="$TMUX_POWERLINE_CUR_SEGMENT_FG"
+
+SEPARATOR_TEXT_DEFAULT="•"
+
+generate_segmentrc() {
+    read -d '' rccontents <<EORC
+# Whether the normal & prefix mode section should be enabled. Should be {"true, "false"}.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_AND_PREFIX_MODE_ENABLED="${NORMAL_AND_PREFIX_MODE_ENABLED_DEFAULT}"
+# Normal mode text & color overrides. Defaults to "normal" & the segment foreground color set in the theme used.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_MODE_TEXT="${NORMAL_MODE_TEXT_DEFAULT}"
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_MODE_TEXT_COLOR=""
+# Prefix mode text & color overrides. Defaults to "prefix" & the segment foreground color set in the theme used.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_PREFIX_MODE_TEXT="${PREFIX_MODE_TEXT_DEFAULT}"
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_PREFIX_MODE_TEXT_COLOR=""
+# Whether the mouse mode section should be enabled. Should be {"true, "false"}.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_ENABLED="${MOUSE_MODE_ENABLED_DEFAULT}"
+# Mouse mode text & color overrides. Defaults to "mouse" & the segment foreground color set in the theme used.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_TEXT="${MOUSE_MODE_TEXT_DEFAULT}"
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_TEXT_COLOR=""
+# Whether the copy mode section should be enabled. Should be {"true, "false"}.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_ENABLED="${COPY_MODE_ENABLED_DEFAULT}"
+# Copy mode text & color overrides. Defaults to "copy" & the segment foreground color set in the theme used.
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT="${COPY_MODE_TEXT_DEFAULT}"
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT_COLOR=""
+# Separator text override. Defaults to "•".
+export TMUX_POWERLINE_SEG_MODE_INDICATOR_SEPARATOR_TEXT="${SEPARATOR_TEXT_DEFAULT}"
+EORC
+    echo "$rccontents"
+}
 
 run_segment() {
-        prefix_indicator="#[bg=${bg}]#{?client_prefix,#[fg=${prefix_mode_fg}]${prefix_pressed_text},#[fg=${normal_mode_fg}]${normal_mode_text}}"
-        normal_or_copy_indicator="#[bg=${bg}]#{?pane_in_mode,#[fg=${copy_mode_fg}]${copy_mode_text},#[fg=${normal_mode_fg}]${insert_mode_text}}";
-        echo $prefix_indicator "#[fg=${normal_mode_fg}]${separator}" $normal_or_copy_indicator
+    __process_settings
+
+    # Colors.
+    normal_text_color="#[fg=$TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_MODE_TEXT_COLOR]"
+    prefix_text_color="#[fg=$TMUX_POWERLINE_SEG_MODE_INDICATOR_PREFIX_MODE_TEXT_COLOR]"
+    mouse_text_color="#[fg=$TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_TEXT_COLOR]"
+    copy_text_color="#[fg=$TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT_COLOR]"
+
+    # Separator.
+    separator="#[fg=$TMUX_POWERLINE_CUR_SEGMENT_FG]$TMUX_POWERLINE_SEG_MODE_INDICATOR_SEPARATOR_TEXT"
+
+    # Populate segment.
+    segment=""
+    __normal_and_prefix_mode_indicator
+    __mouse_mode_indicator
+    # Copy mode should always be populated last; see comments in
+    # __copy_mode_indicator for more details.
+    __copy_mode_indicator
+
+    echo $segment
+    return 0
+}
+
+__normal_and_prefix_mode_indicator() {
+    if [ "$TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_AND_PREFIX_MODE_ENABLED" != "true" ]; then
         return 0
+    fi
+
+    normal_mode="$normal_text_color$TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_MODE_TEXT"
+    prefix_mode="$prefix_text_color$TMUX_POWERLINE_SEG_MODE_INDICATOR_PREFIX_MODE_TEXT"
+    normal_and_prefix_indicator="#{?client_prefix,$prefix_mode,$normal_mode}"
+
+    if [ -z "$segment" ]; then
+        segment+="$normal_and_prefix_indicator"
+    else
+        segment+=" $separator $normal_and_prefix_indicator"
+    fi
+}
+
+__mouse_mode_indicator() {
+    if [ "$TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_ENABLED" != "true" ]; then
+        return 0
+    fi
+
+    # Mouse mode status - check window, then session, then global settings.
+    mouse_mode_status=$(tmux show-options -w | grep mouse | cut -d ' ' -f2) # Window-level options
+    if [ -z "$mouse_mode_status" ]; then
+        mouse_mode_status=$(tmux show-options | grep mouse | cut -d ' ' -f2) # Session-level options
+        if [ -z "$mouse_mode_status" ]; then
+            mouse_mode_status=$(tmux show-options -g | grep mouse | cut -d ' ' -f2) # Global options
+        fi
+    fi
+
+    if [ "$mouse_mode_status" != "on" ]; then
+        return 0
+    fi
+
+    mouse_indicator="$mouse_text_color$TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_TEXT"
+
+    if [ -z "$segment" ]; then
+        segment+="$mouse_indicator"
+    else
+        segment+=" $separator $mouse_indicator"
+    fi
+}
+
+__copy_mode_indicator() {
+    if [ "$TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_ENABLED" != "true" ]; then
+        return 0
+    fi
+
+    # Note that so long as the *_COPY_MODE_ENABLED flag is set, this will always
+    # add a non-empty section to the segment, regardless of whether copy mode is
+    # actually active. This is because this block of code uses tmux's #()/#{}
+    # syntax for command substitution that doesn't get evaluated until runtime,
+    # so for the purposes of this shell script it's always non-empty.
+    #
+    # Because of this, __copy_mode_indicator should always be called last
+    # (i.e. it will always be the rightmost section of the segment), otherwise
+    # the separator will be printed even if copy mode isn't active.
+    copy_mode="$copy_text_color$TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT"
+    if [ -z "$segment" ]; then
+        segment+="#{?pane_in_mode,$copy_mode,}"
+    else
+        segment+="#{?pane_in_mode, $separator $copy_mode,}"
+    fi
+}
+
+__process_settings() {
+    if [ -z "$TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_AND_PREFIX_MODE_ENABLED" ]; then
+        export TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_AND_PREFIX_MODE_ENABLED="${NORMAL_AND_PREFIX_MODE_ENABLED_DEFAULT}"
+    fi
+    if [ -z "$TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_MODE_TEXT" ]; then
+        export TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_MODE_TEXT="${NORMAL_MODE_TEXT_DEFAULT}"
+    fi
+    if [ -z "$TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_MODE_TEXT_COLOR" ]; then
+        export TMUX_POWERLINE_SEG_MODE_INDICATOR_NORMAL_MODE_TEXT_COLOR="${NORMAL_MODE_TEXT_COLOR_DEFAULT}"
+    fi
+    if [ -z "$TMUX_POWERLINE_SEG_MODE_INDICATOR_PREFIX_MODE_TEXT" ]; then
+        export TMUX_POWERLINE_SEG_MODE_INDICATOR_PREFIX_MODE_TEXT="${PREFIX_MODE_TEXT_DEFAULT}"
+    fi
+    if [ -z "$TMUX_POWERLINE_SEG_MODE_INDICATOR_PREFIX_MODE_TEXT_COLOR" ]; then
+        export TMUX_POWERLINE_SEG_MODE_INDICATOR_PREFIX_MODE_TEXT_COLOR="${PREFIX_MODE_TEXT_COLOR_DEFAULT}"
+    fi
+    if [ -z "$TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_ENABLED" ]; then
+        export TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_ENABLED="${MOUSE_MODE_ENABLED_DEFAULT}"
+    fi
+    if [ -z "$TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_TEXT" ]; then
+        export TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_TEXT="${MOUSE_MODE_TEXT_DEFAULT}"
+    fi
+    if [ -z "$TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_TEXT_COLOR" ]; then
+        export TMUX_POWERLINE_SEG_MODE_INDICATOR_MOUSE_MODE_TEXT_COLOR="${MOUSE_MODE_TEXT_COLOR_DEFAULT}"
+    fi
+    if [ -z "$TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_ENABLED" ]; then
+        export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_ENABLED="${COPY_MODE_ENABLED_DEFAULT}"
+    fi
+    if [ -z "$TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT" ]; then
+        export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT="${COPY_MODE_TEXT_DEFAULT}"
+    fi
+    if [ -z "$TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT_COLOR" ]; then
+        export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT_COLOR="${COPY_MODE_TEXT_COLOR_DEFAULT}"
+    fi
+    if [ -z "$TMUX_POWERLINE_SEG_MODE_INDICATOR_SEPARATOR_TEXT" ]; then
+        export TMUX_POWERLINE_SEG_MODE_INDICATOR_SEPARATOR_TEXT="${SEPARATOR_TEXT_DEFAULT}"
+    fi
 }

--- a/segments/mode_indicator.sh
+++ b/segments/mode_indicator.sh
@@ -39,7 +39,7 @@ COPY_MODE_ENABLED_DEFAULT="true"
 COPY_MODE_TEXT_DEFAULT="copy"
 COPY_MODE_TEXT_COLOR_DEFAULT="$TMUX_POWERLINE_CUR_SEGMENT_FG"
 
-SEPARATOR_TEXT_DEFAULT="•"
+SEPARATOR_TEXT_DEFAULT=" • "
 
 generate_segmentrc() {
     read -d '' rccontents <<EORC
@@ -61,7 +61,7 @@ export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_ENABLED="${COPY_MODE_ENABLED_
 # Copy mode text & color overrides. Defaults to "copy" & the segment foreground color set in the theme used.
 export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT="${COPY_MODE_TEXT_DEFAULT}"
 export TMUX_POWERLINE_SEG_MODE_INDICATOR_COPY_MODE_TEXT_COLOR=""
-# Separator text override. Defaults to "•".
+# Separator text override. Defaults to " • ".
 export TMUX_POWERLINE_SEG_MODE_INDICATOR_SEPARATOR_TEXT="${SEPARATOR_TEXT_DEFAULT}"
 EORC
     echo "$rccontents"
@@ -103,7 +103,7 @@ __normal_and_prefix_mode_indicator() {
     if [ -z "$segment" ]; then
         segment+="$normal_and_prefix_indicator"
     else
-        segment+=" $separator $normal_and_prefix_indicator"
+        segment+="$separator$normal_and_prefix_indicator"
     fi
 }
 
@@ -130,7 +130,7 @@ __mouse_mode_indicator() {
     if [ -z "$segment" ]; then
         segment+="$mouse_indicator"
     else
-        segment+=" $separator $mouse_indicator"
+        segment+="$separator$mouse_indicator"
     fi
 }
 
@@ -152,7 +152,7 @@ __copy_mode_indicator() {
     if [ -z "$segment" ]; then
         segment+="#{?pane_in_mode,$copy_mode,}"
     else
-        segment+="#{?pane_in_mode, $separator $copy_mode,}"
+        segment+="#{?pane_in_mode,$separator$copy_mode,}"
     fi
 }
 

--- a/segments/vcs_branch.sh
+++ b/segments/vcs_branch.sh
@@ -64,7 +64,7 @@ __parse_git_branch() {
 	branch=${branch#refs\/heads\/}
 	branch=$(__truncate_branch_name $branch)
 
-	echo -n "#[fg=colour${git_colour}]${branch_symbol} #[fg=colour${TMUX_POWERLINE_CUR_SEGMENT_FG}]${branch}"
+	echo -n "#[fg=colour${git_colour}]${branch_symbol} #[fg=${TMUX_POWERLINE_CUR_SEGMENT_FG}]${branch}"
 }
 
 # Show SVN branch.
@@ -85,7 +85,7 @@ __parse_svn_branch() {
 
 	local branch=$(echo "${svn_url}" | grep -E -o '[^/]+$')
 	branch=$(__truncate_branch_name $branch)
-	echo "#[fg=colour${svn_colour}]${branch_symbol} #[fg=colour${TMUX_POWERLINE_CUR_SEGMENT_FG}]${branch}"
+	echo "#[fg=colour${svn_colour}]${branch_symbol} #[fg=${TMUX_POWERLINE_CUR_SEGMENT_FG}]${branch}"
 }
 
 __parse_hg_branch() {
@@ -101,7 +101,7 @@ __parse_hg_branch() {
 
 	local branch=$(echo "$summary" | grep 'branch:' | cut -d ' ' -f2)
 	branch=$(__truncate_branch_name $branch)
-	echo "#[fg=colour${hg_colour}]${branch_symbol} #[fg=colour${TMUX_POWERLINE_CUR_SEGMENT_FG}]${branch}"
+	echo "#[fg=colour${hg_colour}]${branch_symbol} #[fg=${TMUX_POWERLINE_CUR_SEGMENT_FG}]${branch}"
 }
 
 

--- a/segments/vcs_modified.sh
+++ b/segments/vcs_modified.sh
@@ -61,7 +61,7 @@ __parse_svn_stats() {
 
 	#print
 	if [[ $modified -gt 0 ]] ; then
-		local ret="#[fg=colour${TMUX_POWERLINE_CUR_SEGMENT_FG}]±${modified}"
+		local ret="#[fg=${TMUX_POWERLINE_CUR_SEGMENT_FG}]±${modified}"
 	fi
 	if [[ $conflicted -gt 0 ]] ; then
 		local ret="#[fg=colour${svn_colour}]ϟ${conflicted} ${ret}"

--- a/themes/default.sh
+++ b/themes/default.sh
@@ -84,6 +84,7 @@ if [ -z $TMUX_POWERLINE_LEFT_STATUS_SEGMENTS ]; then
 	TMUX_POWERLINE_LEFT_STATUS_SEGMENTS=(
 		"tmux_session_info 148 234" \
 		"hostname 33 0" \
+		#"mode_indicator 165 0" \
 		#"ifstat 30 255" \
 		#"ifstat_sys 30 255" \
 		"lan_ip 24 255 ${TMUX_POWERLINE_SEPARATOR_RIGHT_THIN}" \
@@ -107,7 +108,7 @@ if [ -z $TMUX_POWERLINE_RIGHT_STATUS_SEGMENTS ]; then
 		"load 237 167" \
 		#"tmux_mem_cpu_load 234 136" \
 		"battery 137 127" \
-        #"air ${TMUX_POWERLINE_SEG_AIR_COLOR} 255" \
+		#"air ${TMUX_POWERLINE_SEG_AIR_COLOR} 255" \
 		"weather 37 255" \
 		#"rainbarf 0 ${TMUX_POWERLINE_DEFAULT_FOREGROUND_COLOR}" \
 		#"xkb_layout 125 117" \


### PR DESCRIPTION
#### Overview

Rewrote the `mode_indicator.sh` segment from scratch to expose settings to users & make more idiomatic to how segments are now written — seems like it was [written in 2017](https://github.com/erikw/tmux-powerline/pull/247/files) & hadn't been updated since then.

#### Screenshots

Example screenshots with default values, i.e. how it would look out of the box with generated `config.sh` & using default theme:

- _normal mode, mouse mode on_
![image](https://github.com/erikw/tmux-powerline/assets/7005546/6e07983b-2947-44af-bee3-dbf4c6caffd8)

- _prefix mode, mouse mode on_
![image](https://github.com/erikw/tmux-powerline/assets/7005546/6fccad79-d1e8-4f5f-a462-28ef7cccc36d)

- _normal mode, mouse mode on, in copy mode_
![image](https://github.com/erikw/tmux-powerline/assets/7005546/9b004770-dffc-4300-ba50-eeccb10ba258)

Example screenshots with custom values with custom theme, e.g `normal`→`•`, `prefix`→`^`, `mouse`→`🐭`, `copy`→`📋`, `separator`→`|`:

- _normal mode, mouse mode on, in copy mode_
![image](https://github.com/erikw/tmux-powerline/assets/7005546/c1baf069-9492-4363-92a6-e5d6b34050c4)

- _prefix mode, mouse mode disabled_
![image](https://github.com/erikw/tmux-powerline/assets/7005546/3b1e6428-bd12-4540-92c2-f6128c43c06a)

...etc, I think this captures the gist, this segment is now very customizable.

#### Testing
- Verified that `config.sh.default` is generated with new section as expected after `generate_config.sh`.
- Verified that all newly exposed settings in `config.sh` have correct default behavior, & can be overwritten as expected.
- Verified that background & foreground colors set through theme are respected (if not overridden in `config.sh`).
- Verified that minor changes to `lib/powerline.sh` & `segments/vcs_{branch,modified}.sh` didn't break anything.
