### PR TITLE
Set `message-style` to also be default powerline style.

### DIFF
--- a/main.tmux
+++ b/main.tmux
@@ -16,6 +16,7 @@ tmux set-option -g status "$TMUX_POWERLINE_STATUS_VISIBILITY"
 tmux set-option -g status-interval "$TMUX_POWERLINE_STATUS_INTERVAL"
 tmux set-option -g status-justify "$TMUX_POWERLINE_STATUS_JUSTIFICATION"
 tmux set-option -g status-style "$TMUX_POWERLINE_STATUS_STYLE"
+tmux set-option -g message-style "$TMUX_POWERLINE_STATUS_STYLE"
 
 tmux set-option -g status-left-length $TMUX_POWERLINE_STATUS_LEFT_LENGTH
 tmux set-option -g status-right-length $TMUX_POWERLINE_STATUS_RIGHT_LENGTH


### PR DESCRIPTION
Like `status-style`, which sets the color scheme of the entire status line (added in https://github.com/erikw/tmux-powerline/pull/362), `message-style` sets the color scheme of the command/prompt mode (i.e. when you press `Prefix` + `:`). This makes the status line color experience even more consistent.

Screenshots:
_Before_
![image](https://github.com/erikw/tmux-powerline/assets/7005546/ea28796f-4d83-4783-9d1c-430c3e13b1d9)


_After_
![image](https://github.com/erikw/tmux-powerline/assets/7005546/64d31741-938e-455f-82dc-81e8c7a36a1e)

[Re this comment](https://github.com/erikw/tmux-powerline/pull/363#issuecomment-1993622395): ok _this_ is the last PR 😅
