### PR TITLE
Use format directly with tmux status line

### DIFF
--- a/segments/tmux_session_info.sh
+++ b/segments/tmux_session_info.sh
@@ -20,6 +20,6 @@ __process_settings() {
 
 run_segment() {
 	__process_settings
-	tmux display-message -p "$TMUX_POWERLINE_SEG_TMUX_SESSION_INFO_FORMAT"
+	echo "${TMUX_POWERLINE_SEG_TMUX_SESSION_INFO_FORMAT}"
 	return 0
 }


### PR DESCRIPTION
* tmux display-message does seem to retrieve global "current" or "active" information whereas native format shows "local" session/window/pane information

fix #359