### PR TITLE
Disable JSCPD linter

### DIFF
--- a/.github/workflows/linter-full.yml
+++ b/.github/workflows/linter-full.yml
@@ -33,4 +33,5 @@ jobs:
           VALIDATE_CPP: false
           VALIDATE_CLANG_FORMAT: false
           VALIDATE_PYTHON_PYLINT: false
+          VALIDATE_JSCPD: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/linter-pr.yml
+++ b/.github/workflows/linter-pr.yml
@@ -33,4 +33,5 @@ jobs:
           VALIDATE_CPP: false
           VALIDATE_CLANG_FORMAT: false
           VALIDATE_PYTHON_PYLINT: false
+          VALIDATE_JSCPD: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
currently the repository does contain some copies, which need to be cleaned up before we can re-enable it again