### PR TITLE
Fix segment separator color settings

### DIFF
--- a/themes/bubble.sh
+++ b/themes/bubble.sh
@@ -99,34 +99,46 @@ if [ -z "$TMUX_POWERLINE_WINDOW_STATUS_FORMAT" ]; then
 	)
 fi
 
-# Format: segment_name background_color foreground_color [non_default_separator] [separator_background_color] [separator_foreground_color] [spacing_disable] [separator_disable]
+# Format: segment_name [background_color|default_bg_color] [foreground_color|default_fg_color] [non_default_separator|default_separator] [separator_background_color|no_sep_bg_color]
+#                      [separator_foreground_color|no_sep_fg_color] [spacing_disable|no_spacing_disable] [separator_disable|no_separator_disable]
 #
 # * background_color and foreground_color. Color formatting (see `man tmux` for complete list):
 #   * Named colors, e.g. black, red, green, yellow, blue, magenta, cyan, white
 #   * Hexadecimal RGB string e.g. #ffffff
+#   * 'default_fg_color|default_bg_color' for the default theme bg and fg color
 #   * 'default' for the default tmux color.
 #   * 'terminal' for the terminal's default background/foreground color
 #   * The numbers 0-255 for the 256-color palette. Run `tmux-powerline/color-palette.sh` to see the colors.
 # * non_default_separator - specify an alternative character for this segment's separator
+#   * 'default_separator' for the theme default separator
 # * separator_background_color - specify a unique background color for the separator
+#   * 'no_sep_bg_color' for using the default coloring for the separator
 # * separator_foreground_color - specify a unique foreground color for the separator
+#   * 'no_sep_fg_color' for using the default coloring for the separator
 # * spacing_disable - remove space on left, right or both sides of the segment:
+#   * "no_spacing_disable" - don't disable spacing (default)
 #   * "left_disable" - disable space on the left
 #   * "right_disable" - disable space on the right
 #   * "both_disable" - disable spaces on both sides
-#   * - any other character/string produces no change to default behavior (eg "none", "X", etc.)
 #
 # * separator_disable - disables drawing a separator on this segment, very useful for segments
 #   with dynamic background colours (eg tmux_mem_cpu_load):
+#   * "no_separator_disable" - don't disable the separator (default)
 #   * "separator_disable" - disables the separator
-#   * - any other character/string produces no change to default behavior
 #
 # Example segment with separator disabled and right space character disabled:
-# "hostname 33 0 {TMUX_POWERLINE_SEPARATOR_RIGHT_BOLD} 33 0 right_disable separator_disable"
+# "hostname 33 0 {TMUX_POWERLINE_SEPARATOR_RIGHT_BOLD} 0 0 right_disable separator_disable"
 #
-# Note that although redundant the non_default_separator, separator_background_color and
+# Example segment with spacing characters disabled on both sides but not touching the default coloring:
+# "hostname 33 0 {TMUX_POWERLINE_SEPARATOR_RIGHT_BOLD} no_sep_bg_color no_sep_fg_color both_disable"
+#
+# Example segment with changing the foreground color of the default separator:
+# "hostname 33 0 default_separator no_sep_bg_color 120"
+#
+## Note that although redundant the non_default_separator, separator_background_color and
 # separator_foreground_color options must still be specified so that appropriate index
-# of options to support the spacing_disable and separator_disable features can be used
+# of options to support the spacing_disable and separator_disable features can be used.
+# The default_* and no_* can be used to keep the default behaviour.
 
 # shellcheck disable=SC1143,SC2128
 if [ -z "$TMUX_POWERLINE_LEFT_STATUS_SEGMENTS" ]; then

--- a/themes/default.sh
+++ b/themes/default.sh
@@ -56,18 +56,24 @@ if [ -z "$TMUX_POWERLINE_WINDOW_STATUS_FORMAT" ]; then
 	)
 fi
 
-# Format: segment_name background_color foreground_color [non_default_separator] [separator_background_color] [separator_foreground_color] [spacing_disable] [separator_disable]
+# Format: segment_name [background_color|default_bg_color] [foreground_color|default_fg_color] [non_default_separator|default_separator] [separator_background_color|no_sep_bg_color]
+#                      [separator_foreground_color|no_sep_fg_color] [spacing_disable|no_spacing_disable] [separator_disable|no_separator_disable]
 #
 # * background_color and foreground_color. Color formatting (see `man tmux` for complete list):
 #   * Named colors, e.g. black, red, green, yellow, blue, magenta, cyan, white
 #   * Hexadecimal RGB string e.g. #ffffff
+#   * 'default_fg_color|default_bg_color' for the default theme bg and fg color
 #   * 'default' for the default tmux color.
 #   * 'terminal' for the terminal's default background/foreground color
 #   * The numbers 0-255 for the 256-color palette. Run `tmux-powerline/color-palette.sh` to see the colors.
 # * non_default_separator - specify an alternative character for this segment's separator
+#   * 'default_separator' for the theme default separator
 # * separator_background_color - specify a unique background color for the separator
+#   * 'no_sep_bg_color' for using the default coloring for the separator
 # * separator_foreground_color - specify a unique foreground color for the separator
+#   * 'no_sep_fg_color' for using the default coloring for the separator
 # * spacing_disable - remove space on left, right or both sides of the segment:
+#   * "no_spacing_disable" - don't disable spacing (default)
 #   * "left_disable" - disable space on the left
 #   * "right_disable" - disable space on the right
 #   * "both_disable" - disable spaces on both sides
@@ -75,15 +81,23 @@ fi
 #
 # * separator_disable - disables drawing a separator on this segment, very useful for segments
 #   with dynamic background colours (eg tmux_mem_cpu_load):
+#   * "no_separator_disable" - don't disable the separator (default)
 #   * "separator_disable" - disables the separator
 #   * - any other character/string produces no change to default behavior
 #
 # Example segment with separator disabled and right space character disabled:
-# "hostname 33 0 {TMUX_POWERLINE_SEPARATOR_RIGHT_BOLD} 33 0 right_disable separator_disable"
+# "hostname 33 0 {TMUX_POWERLINE_SEPARATOR_RIGHT_BOLD} 0 0 right_disable separator_disable"
 #
-# Note that although redundant the non_default_separator, separator_background_color and
+# Example segment with spacing characters disabled on both sides but not touching the default coloring:
+# "hostname 33 0 {TMUX_POWERLINE_SEPARATOR_RIGHT_BOLD} no_sep_bg_color no_sep_fg_color both_disable"
+#
+# Example segment with changing the foreground color of the default separator:
+# "hostname 33 0 default_separator no_sep_bg_color 120"
+#
+## Note that although redundant the non_default_separator, separator_background_color and
 # separator_foreground_color options must still be specified so that appropriate index
 # of options to support the spacing_disable and separator_disable features can be used
+# The default_* and no_* can be used to keep the default behaviour.
 
 # shellcheck disable=SC1143,SC2128
 if [ -z "$TMUX_POWERLINE_LEFT_STATUS_SEGMENTS" ]; then


### PR DESCRIPTION
* introduce defaults for all segment config options
* fix actual usage of separator_background_color and separator_foreground_color
* document defaults in themes

fixes #426