### PR TITLE
[ISSUE-444] fix typo "banch" -> "branch"

### DIFF
--- a/segments/vcs_branch.sh
+++ b/segments/vcs_branch.sh
@@ -58,7 +58,7 @@ run_segment() {
 	return 0
 }
 
-# Show git banch.
+# Show git branch.
 __parse_git_branch() {
 	local branch
 


### PR DESCRIPTION
Hi all, this is a PR to fix a minor typo that I found while searching for git branch related components. I recently installed powerline and wanted to add the git branch displayed on the line and while looking through the repo, I found the typo.

Fixes issue https://github.com/erikw/tmux-powerline/issues/444

Changes made in this PR:
1. fixed typo `banch` -> `branch`