### PR TITLE
Modified the Weather segment script to be less complicated

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,8 @@ Some segments have their own requirements. If you enable them in your theme, mak
 * **tmux_mem_cpu_load.sh**: [tmux-mem-cpu-load](https://github.com/thewtex/tmux-mem-cpu-load)
 * **wan_ip.sh**: `curl`
 * **weather.sh**:
-   * Provider *yrno*: `jq`, `curl`, GNU `grep` with Perl regular expression enabled (FreeBSD specific)
+   * Provider *yrno*: `jq`, `curl`
 * **xkb_layout.sh**: X11, XKB
-
-## FreeBSD specific requirements
-Preinstalled `grep` in FreeBSD doesn't support Perl regular expressions. Solution is rather simple -- you need to use `textproc/gnugrep` port instead. You also need to make sure, that it has support for PCRE and is compiled with `--enable-perl-regexp` flag.
-
 
 # Installation
 1. Install [tpm](https://github.com/tmux-plugins/tpm) and make sure it's working.


### PR DESCRIPTION
Original Problem: https://github.com/erikw/tmux-powerline/issues/465

The purpose of this PR:
- Remove unnecessary complications, such as the usages of `stat` and `grep` command based on specific OS.
- Fix a bug when the location are set to `auto` only 1 API is called instead of 2, since `"null"` being handled as a legitimate value. Hence, if one of the API is rate limited, while the other one works fine. The real, actual coordinates never got fetched, which leads to weather API error due to lat and lon are set to `"null"`, as literal strings.
- Adding default values to lat and lon
- Allow tweaking the polling rate frequency of automatic location update (only works when both lat and lon settings are set to `auto`)

New script has been tested on Linux Ubuntu `amd64/aarch64` and MacOS `arm64`