### PR TITLE
Add dropbox_status segment to show the status of your dropbox daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Requirements for the lib to work are:
 ## Segment Requirements
 Some segments have their own requirements. If you enable them in your theme, make sure all requirements are met for those.
 
+* **dropbox_status.sh**: `dropbox-cli`
 * **github_notifications.sh**: `jq`
 * **ifstat.sh**: `ifstat` (there is a simpler segment `ifstat_sys.sh` not using ifstat)
 * **mailcount.sh**

--- a/segments/dropbox_status.sh
+++ b/segments/dropbox_status.sh
@@ -1,0 +1,81 @@
+# shellcheck=bash
+
+# https://www.nerdfonts.com/cheat-sheet?q=nf-fa-dropbox
+TMUX_POWERLINE_SEG_DROPBOX_GLYPH_DEFAULT=$'\uf16b'
+# https://www.nerdfonts.com/cheat-sheet?q=nf-fa-upload
+TMUX_POWERLINE_SEG_DROPBOX_UPLOAD_GLYPH_DEFAULT=$'\uf093'
+# https://www.nerdfonts.com/cheat-sheet?q=nf-fa-download
+TMUX_POWERLINE_SEG_DROPBOX_DOWNLOAD_GLYPH_DEFAULT=$'\uf019'
+# https://www.nerdfonts.com/cheat-sheet?q=nf-fa-bookmark
+TMUX_POWERLINE_SEG_DROPBOX_INDEX_GLYPH_DEFAULT=$'\uf02e'
+# https://www.nerdfonts.com/cheat-sheet?q=nf-oct-sync
+TMUX_POWERLINE_SEG_DROPBOX_SYNC_GLYPH_DEFAULT=$'\uf46a'
+
+__dropbox_sed_script() {
+	read -r -d '' sedscript <<EOSED
+s/\(^.*\)\.\.\./\1/g
+s/Syncing \([0-9]\+\) \(.*\)$/\${TMUX_POWERLINE_SEG_DROPBOX_SYNC_GLYPH} \1/g
+s/Indexing \([0-9]\+\) \(.*\)$/\${TMUX_POWERLINE_SEG_DROPBOX_INDEX_GLYPH} \1/g
+s/Uploading \([0-9]\+\) \(.*\)$/\${TMUX_POWERLINE_SEG_DROPBOX_UPLOAD_GLYPH} \1/g
+s/Downloading \([0-9]\+\) \(.*\)$/\${TMUX_POWERLINE_SEG_DROPBOX_DOWNLOAD_GLYPH} \1/g
+s/Syncing \(.*\)$/\${TMUX_POWERLINE_SEG_DROPBOX_SYNC_GLYPH} 1/g
+s/Indexing \(.*\)$/\${TMUX_POWERLINE_SEG_DROPBOX_INDEX_GLYPH} 1/g
+s/Uploading \(.*\)$/\${TMUX_POWERLINE_SEG_DROPBOX_UPLOAD_GLYPH} 1/g
+s/Downloading \(.*\)$/\${TMUX_POWERLINE_SEG_DROPBOX_DOWNLOAD_GLYPH} 1/g
+EOSED
+	echo "$sedscript"
+}
+
+generate_segmentrc() {
+	read -r -d '' rccontents <<EORC
+# The Dropbox glyph to use
+export TMUX_POWERLINE_SEG_DROPBOX_GLYPH="${TMUX_POWERLINE_SEG_DROPBOX_GLYPH_DEFAULT}"
+# Replace 'Uploading' in the status
+export TMUX_POWERLINE_SEG_DROPBOX_UPLOAD_GLYPH="${TMUX_POWERLINE_SEG_DROPBOX_UPLOAD_GLYPH_DEFAULT}"
+# Replace 'Downloading' in the status
+export TMUX_POWERLINE_SEG_DROPBOX_DOWNLOAD_GLYPH="${TMUX_POWERLINE_SEG_DROPBOX_DOWNLOAD_GLYPH_DEFAULT}"
+# Replace 'Indexing' in the status
+export TMUX_POWERLINE_SEG_DROPBOX_INDEX_GLYPH="${TMUX_POWERLINE_SEG_DROPBOX_INDEX_GLYPH_DEFAULT}"
+# Replace 'Syncing' in the status
+export TMUX_POWERLINE_SEG_DROPBOX_SYNC_GLYPH="${TMUX_POWERLINE_SEG_DROPBOX_SYNC_GLYPH_DEFAULT}"
+EORC
+	echo "$rccontents"
+}
+
+run_segment() {
+	__process_settings
+	if ! command -v dropbox-cli &>/dev/null; then
+		printf "%s ${TMUX_POWERLINE_SEG_DROPBOX_GLYPH} " "dropbox-cli not found"
+		return 1
+	fi
+	status_text=$(dropbox-cli status \
+			| sed "$(__dropbox_sed_script)" \
+			| sed -z 's/\n/ /g;s/\(.*\) /\1/g' \
+			| envsubst
+	)
+	if [ "${status_text}" = "Up to date" ]; then return 0; fi
+	if [ "${status_text}" = "Dropbox isn't running!" ]; then
+		printf "#[bg=colour124] %s ${TMUX_POWERLINE_SEG_DROPBOX_GLYPH} " "${status_text}"
+	else
+		printf "%s ${TMUX_POWERLINE_SEG_DROPBOX_GLYPH} " "${status_text}"
+	fi
+	return 0
+}
+
+__process_settings() {
+	if [ -z "$TMUX_POWERLINE_SEG_DROPBOX_GLYPH" ]; then
+		export TMUX_POWERLINE_SEG_DROPBOX_GLYPH="${TMUX_POWERLINE_SEG_DROPBOX_GLYPH_DEFAULT}"
+	fi
+	if [ -z "$TMUX_POWERLINE_SEG_DROPBOX_UPLOAD_GLYPH" ]; then
+		export TMUX_POWERLINE_SEG_DROPBOX_UPLOAD_GLYPH="${TMUX_POWERLINE_SEG_DROPBOX_UPLOAD_GLYPH_DEFAULT}"
+	fi
+	if [ -z "$TMUX_POWERLINE_SEG_DROPBOX_DOWNLOAD_GLYPH" ]; then
+		export TMUX_POWERLINE_SEG_DROPBOX_DOWNLOAD_GLYPH="${TMUX_POWERLINE_SEG_DROPBOX_DOWNLOAD_GLYPH_DEFAULT}"
+	fi
+	if [ -z "$TMUX_POWERLINE_SEG_DROPBOX_INDEX_GLYPH" ]; then
+		export TMUX_POWERLINE_SEG_DROPBOX_INDEX_GLYPH="${TMUX_POWERLINE_SEG_DROPBOX_INDEX_GLYPH_DEFAULT}"
+	fi
+	if [ -z "$TMUX_POWERLINE_SEG_DROPBOX_SYNC_GLYPH" ]; then
+		export TMUX_POWERLINE_SEG_DROPBOX_SYNC_GLYPH="${TMUX_POWERLINE_SEG_DROPBOX_SYNC_GLYPH_DEFAULT}"
+	fi
+}

--- a/segments/dropbox_status.sh
+++ b/segments/dropbox_status.sh
@@ -42,7 +42,7 @@ EORC
 run_segment() {
 	__process_settings
 	if ! command -v dropbox-cli &>/dev/null; then
-		printf "%s ${TMUX_POWERLINE_SEG_DROPBOX_GLYPH} " "dropbox-cli not found"
+		printf "#[bg=colour124] %s ${TMUX_POWERLINE_SEG_DROPBOX_GLYPH} " "dropbox-cli not found"
 		return 1
 	fi
 	status_text=$(dropbox-cli status \

--- a/segments/dropbox_status.sh
+++ b/segments/dropbox_status.sh
@@ -11,8 +11,7 @@ TMUX_POWERLINE_SEG_DROPBOX_INDEX_GLYPH_DEFAULT=$'\uf02e'
 # https://www.nerdfonts.com/cheat-sheet?q=nf-oct-sync
 TMUX_POWERLINE_SEG_DROPBOX_SYNC_GLYPH_DEFAULT=$'\uf46a'
 
-__dropbox_sed_script() {
-	read -r -d '' sedscript <<EOSED
+IFS= read -r -d '' TMUX_POWERLINE_SEG_DROPBOX_SED_SCRIPT <<EOSED
 s/\(^.*\)\.\.\./\1/g
 s/Syncing \([0-9]\+\) \(.*\)$/\${TMUX_POWERLINE_SEG_DROPBOX_SYNC_GLYPH} \1/g
 s/Indexing \([0-9]\+\) \(.*\)$/\${TMUX_POWERLINE_SEG_DROPBOX_INDEX_GLYPH} \1/g
@@ -23,8 +22,6 @@ s/Indexing \(.*\)$/\${TMUX_POWERLINE_SEG_DROPBOX_INDEX_GLYPH} 1/g
 s/Uploading \(.*\)$/\${TMUX_POWERLINE_SEG_DROPBOX_UPLOAD_GLYPH} 1/g
 s/Downloading \(.*\)$/\${TMUX_POWERLINE_SEG_DROPBOX_DOWNLOAD_GLYPH} 1/g
 EOSED
-	echo "$sedscript"
-}
 
 generate_segmentrc() {
 	read -r -d '' rccontents <<EORC
@@ -49,7 +46,7 @@ run_segment() {
 		return 1
 	fi
 	status_text=$(dropbox-cli status \
-			| sed "$(__dropbox_sed_script)" \
+			| sed "$TMUX_POWERLINE_SEG_DROPBOX_SED_SCRIPT" \
 			| sed -z 's/\n/ /g;s/\(.*\) /\1/g' \
 			| envsubst
 	)

--- a/segments/dropbox_status.sh
+++ b/segments/dropbox_status.sh
@@ -1,4 +1,4 @@
-# shellcheck=bash
+# shellcheck shell=bash
 
 # https://www.nerdfonts.com/cheat-sheet?q=nf-fa-dropbox
 TMUX_POWERLINE_SEG_DROPBOX_GLYPH_DEFAULT=$'\uf16b'


### PR DESCRIPTION
This PR adds the `dropbox_status` segment which shows a summary of the activity of your dropbox daemon using the `dropbox-cli` utility.

This segment requires users to install the `dropbox-cli` utility.

**Functionality**:

- When dropbox is doing nothing, the segment is hidden.

- When dropbox is syncing/uploading/downloading/indexing files, icons (glyphs) and file counts are shown. The glyphs can be set by the user.

![image](https://github.com/user-attachments/assets/f89bd0b3-09e8-40bc-99b3-22e351776ced)

- When dropbox is not running, a warning message is displayed:

![image](https://github.com/user-attachments/assets/0b2e910f-7b73-48da-af9e-e1d712e089fc)

- If the `dropbox-cli` utility wasn't found, a warning message is displayed:

![image](https://github.com/user-attachments/assets/16206077-27ad-4edd-bd50-554571fc2d78)

Dropbox [recently announced](https://www.dropboxforum.com/discussions/101001016/can-i-use-the-dropbox-desktop-app-on-linux-without-appindicator/832548) changes to their system tray icon on Linux which means the icon and its notifications will stop working for some users. This segment can be used to replace the visual indicator which the system tray icon would otherwise provide.

**Note**: I haven't been able to test this segment on Mac as I'm on Linux and don't have access to a Mac.