### PR TITLE
Remove decimal part from "cpu_temp" segment

### DIFF
--- a/lib/cpu_temp_helper.sh
+++ b/lib/cpu_temp_helper.sh
@@ -1,16 +1,22 @@
 # shellcheck shell=bash
 
 tp_cpu_temp_value() {
+	local temp
+
 	if tp_shell_is_macos; then
-		smctemp -c | bc -l
+		temp=$(smctemp -c | bc -l)
 	elif tp_shell_is_linux; then
-		sensors \
+		temp=$(sensors \
 			| grep "$TMUX_POWERLINE_SEG_CPU_TEMP_SENSORS_LINE_MARKER" -m 1 \
-			| sed -e 's/[^+]*+\([\s0-9\.]*\).*/\1/' | bc -l
+			| sed -e 's/[^+]*+\([\s0-9\.]*\).*/\1/' | bc -l)
 	fi
+
+	tp_round "$temp" 0
 }
 
 tp_cpu_temp_at_least() {
-	echo "$(tp_cpu_temp_value) >= $1" | bc -l
+	local threshold_temp="$1"
+
+	echo "$(tp_cpu_temp_value) >= $threshold_temp" | bc -l
 }
 

--- a/lib/mem_used_helper.sh
+++ b/lib/mem_used_helper.sh
@@ -47,12 +47,12 @@ __tp_mem_used_info() {
 
 tp_mem_used_gigabytes() {
 	read -r mem_used_bytes mem_total_bytes < <(__tp_mem_used_info)
-	__round "$(echo "$mem_used_bytes / 1073741824" | bc -l)" 2
+	tp_round "$(echo "$mem_used_bytes / 1073741824" | bc -l)" 2
 }
 
 tp_mem_used_megabytes() {
 	read -r mem_used_bytes mem_total_bytes < <(__tp_mem_used_info)
-	__round "$(echo "$mem_used_bytes / 1048576" | bc -l)" 0
+	tp_round "$(echo "$mem_used_bytes / 1048576" | bc -l)" 0
 }
 
 tp_mem_used_percentage_at_least() {
@@ -60,14 +60,4 @@ tp_mem_used_percentage_at_least() {
 	read -r mem_used_bytes mem_total_bytes < <(__tp_mem_used_info)
 	echo "($mem_used_bytes / $mem_total_bytes) * 100 >= $threshold_percentage" | bc -l
 }
-
-# source https://askubuntu.com/a/179949
-# Rounds positive numbers up to the number of digits to the right of the decimal point.
-# Example: "__round 1.2345 3" -> "((1000 * 1.2345) + 0.5) / 1000" -> "1.235"
-__round() {
-	local number="$1"
-	local digits="$2"
-
-	env printf "%.${digits}f" "$(echo "scale=${digits};(((10^${digits})*${number})+0.5)/(10^${digits})" | bc)"
-};
 

--- a/lib/util.sh
+++ b/lib/util.sh
@@ -66,3 +66,14 @@ tp_err_seg() {
 	# TMUX_POWERLINE_CUR_SEGMENT_NAME is being set before each segment run
 	tp_err "${TMUX_POWERLINE_CUR_SEGMENT_NAME:-unknown_segment}" "$*"
 }
+
+# source https://askubuntu.com/a/179949
+# Rounds positive numbers up to the number of digits to the right of the decimal point.
+# Example: "tp_round 1.2345 3" -> "((1000 * 1.2345) + 0.5) / 1000" -> "1.235"
+tp_round() {
+	local number="$1"
+	local digits="$2"
+
+	env printf "%.${digits}f" "$(echo "scale=${digits};(((10^${digits})*${number})+0.5)/(10^${digits})" | bc)"
+};
+


### PR DESCRIPTION
CPU temperature decimal part doesn't make much sense, only occupies space. Especially on Linux it is always zero on my machines. 

Before:
<img width="84" height="28" alt="before" src="https://github.com/user-attachments/assets/dc78964e-bd44-4981-8bda-ede1ead18881" />

After:
<img width="72" height="22" alt="after" src="https://github.com/user-attachments/assets/0b5702a1-a3a8-4ed0-93f4-fdd833ce5b91" />
