### PR TITLE
fix(now_playing): remove hardcoded trim from macOS scripts, enhance Apple Music

### DIFF
--- a/segments/np_apple_music.script
+++ b/segments/np_apple_music.script
@@ -1,5 +1,5 @@
 #!/usr/bin/env osascript
-# Returns the current playing song in iTunes for macOS.
+# Returns the current playing song in Apple Music for macOS.
 
 tell application "System Events"
 	set process_list to (name of every process)
@@ -7,16 +7,13 @@ end tell
 
 if process_list contains "Music" then
 	tell application "Music"
-		if player state is playing then
+		if player state is playing or player state is paused then
 			set track_name to name of current track
 			set artist_name to artist of current track
-			#			set album_name to album of current track
-			set trim_length to 40
-			set now_playing to  artist_name & " - " & track_name
-			if length of now_playing is less than trim_length then
-				set now_playing_trim to now_playing
+			if player state is playing then
+				set now_playing to "► " & artist_name & " - " & track_name
 			else
-				set now_playing_trim to characters 1 thru trim_length of now_playing as string
+				set now_playing to "❙❙ " & artist_name & " - " & track_name
 			end if
 		end if
 	end tell

--- a/segments/np_itunes.script
+++ b/segments/np_itunes.script
@@ -11,13 +11,7 @@ if process_list contains "iTunes" then
 			set track_name to name of current track
 			set artist_name to artist of current track
 			#			set album_name to album of current track
-			set trim_length to 40
-			set now_playing to  artist_name & " - " & track_name
-			if length of now_playing is less than trim_length then
-				set now_playing_trim to now_playing
-			else
-				set now_playing_trim to characters 1 thru trim_length of now_playing as string
-			end if
+			set now_playing to artist_name & " - " & track_name
 		end if
 	end tell
 end if

--- a/segments/np_spotify_mac.script
+++ b/segments/np_spotify_mac.script
@@ -11,16 +11,10 @@ if process_list contains "Spotify" then
 			set track_name to name of current track
 			set artist_name to artist of current track
 			#set album_name to album of current track
-			set trim_length to 40
 			if player state is playing then
 				set now_playing to "► " & artist_name & " - " & track_name
 			else
 				set now_playing to "❙❙ " & artist_name & " - " & track_name
-			end if
-			if length of now_playing is less than trim_length then
-				set now_playing_trim to now_playing
-			else
-				set now_playing_trim to characters 1 thru trim_length of now_playing as string
 			end if
 		end if
 	end tell


### PR DESCRIPTION
## Summary

Closes #508.

The macOS now_playing scripts (`np_apple_music.script`, `np_itunes.script`, `np_spotify_mac.script`) all contained a hardcoded 40-character trim that was applied before the output reached the bash layer. This meant `TMUX_POWERLINE_SEG_NOW_PLAYING_MAX_LEN` and `TRIM_METHOD=roll` had no effect for these players — the text was always pre-truncated to 40 chars and the roll logic never triggered.

The fix removes the trim from all three scripts and lets `now_playing.sh` handle length uniformly, consistent with how all other players work.

### Changes

- **`np_apple_music.script`**: Remove hardcoded trim. Add paused state support and ►/❙❙ play/pause icons to match `np_spotify_mac.script` behaviour.
- **`np_itunes.script`**: Remove hardcoded trim.
- **`np_spotify_mac.script`**: Remove hardcoded trim (play/pause icons were already present).

## Test plan

- [ ] Set `TRIM_METHOD=roll` and `MAX_LEN=40` — confirm text rolls when track name exceeds 40 chars
- [ ] Pause Apple Music — confirm track info remains visible with ❙❙ icon
- [ ] Play Apple Music — confirm ► icon appears
- [ ] Verify Spotify and iTunes behaviour unchanged (trim/roll now handled by bash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)