### PR TITLE
fix(segments): make weather and wan_ip fetches non-blocking; add weather icon style option

### DIFF
--- a/segments/wan_ip.sh
+++ b/segments/wan_ip.sh
@@ -1,5 +1,7 @@
 # shellcheck shell=bash
 # Prints the WAN IP address. The result is cached and updated according to $update_period.
+#
+# Network fetch is done in a background process so tmux rendering is never blocked.
 TMUX_POWERLINE_SEG_WAN_IP_SYMBOL="${TMUX_POWERLINE_SEG_WAN_IP_SYMBOL:-ⓦ }"
 TMUX_POWERLINE_SEG_WAN_IP_SYMBOL_COLOUR="${TMUX_POWERLINE_SEG_WAN_IP_SYMBOL_COLOUR:-255}"
 
@@ -15,34 +17,27 @@ EORC
 
 run_segment() {
 	local tmp_file="${TMUX_POWERLINE_DIR_TEMPORARY}/wan_ip.txt"
+	local lock_file="${TMUX_POWERLINE_DIR_TEMPORARY}/wan_ip_refresh.lock"
+	local update_period=900
 	local wan_ip
 
+	# Always return cached data immediately, even if stale
 	if [ -f "$tmp_file" ]; then
-		if tp_shell_is_macos || tp_shell_is_bsd; then
-			stat >/dev/null 2>&1 && is_gnu_stat=false || is_gnu_stat=true
-			if [ "$is_gnu_stat" == "true" ]; then
-				last_update=$(stat -c "%Y" "${tmp_file}")
-			else
-				last_update=$(stat -f "%m" "${tmp_file}")
-			fi
-		elif tp_shell_is_linux || [ -z "$is_gnu_stat" ]; then
-			last_update=$(stat -c "%Y" "${tmp_file}")
-		fi
-
-		time_now=$(date +%s)
-		update_period=900
-		up_to_date=$(echo "(${time_now}-${last_update}) < ${update_period}" | bc)
-
-		if [ "$up_to_date" -eq 1 ]; then
-			wan_ip=$(cat "${tmp_file}")
-		fi
+		wan_ip=$(cat "$tmp_file")
 	fi
 
-	if [ -z "$wan_ip" ]; then
-		if wan_ip=$(curl --max-time 2 -s https://whatismyip.akamai.com/); then
-			echo "${wan_ip}" >"$tmp_file"
-		elif [ -f "${tmp_file}" ]; then
-			wan_ip=$(cat "$tmp_file")
+	# Check if cache is stale or missing; if so, refresh in background
+	if ! __wan_ip_cache_is_fresh "$tmp_file" "$update_period"; then
+		if [ ! -f "$lock_file" ]; then
+			(
+				trap 'rm -f "$lock_file"' EXIT
+				touch "$lock_file"
+				local fresh_ip
+				if fresh_ip=$(curl --max-time 2 -s https://whatismyip.akamai.com/); then
+					echo "${fresh_ip}" > "$tmp_file"
+				fi
+			) &
+			disown
 		fi
 	fi
 
@@ -51,4 +46,23 @@ run_segment() {
 	fi
 
 	return 0
+}
+
+__wan_ip_cache_is_fresh() {
+	local tmp_file="$1"
+	local update_period="$2"
+	[ -f "$tmp_file" ] || return 1
+	local last_update time_now
+	if tp_shell_is_macos || tp_shell_is_bsd; then
+		stat >/dev/null 2>&1 && is_gnu_stat=false || is_gnu_stat=true
+		if [ "$is_gnu_stat" == "true" ]; then
+			last_update=$(stat -c "%Y" "$tmp_file")
+		else
+			last_update=$(stat -f "%m" "$tmp_file")
+		fi
+	else
+		last_update=$(stat -c "%Y" "$tmp_file")
+	fi
+	time_now=$(date +%s)
+	[ "$(echo "(${time_now}-${last_update}) < ${update_period}" | bc)" -eq 1 ]
 }

--- a/segments/weather.sh
+++ b/segments/weather.sh
@@ -1,6 +1,8 @@
 # shellcheck shell=bash
 # Prints the current weather in Celsius, Fahrenheits or lord Kelvins. The forecast is cached and updated with a period.
 # To configure your location, set TMUX_POWERLINE_SEG_WEATHER_(LAT|LON) in the tmux-powerline config file.
+#
+# Network fetches are done in a background process so tmux rendering is never blocked.
 
 # shellcheck source=lib/util.sh
 source "${TMUX_POWERLINE_DIR_LIB}/util.sh"
@@ -8,15 +10,14 @@ source "${TMUX_POWERLINE_DIR_LIB}/util.sh"
 TMUX_POWERLINE_SEG_WEATHER_DATA_PROVIDER_DEFAULT="yrno"
 TMUX_POWERLINE_SEG_WEATHER_UNIT_DEFAULT="c"
 TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD_DEFAULT="600"
-TMUX_POWERLINE_SEG_WEATHER_LOCATION_UPDATE_PERIOD_DEFAULT="86400" # 24 hours
+TMUX_POWERLINE_SEG_WEATHER_LOCATION_UPDATE_PERIOD_DEFAULT="86400"
 TMUX_POWERLINE_SEG_WEATHER_LAT_DEFAULT="auto"
 TMUX_POWERLINE_SEG_WEATHER_LON_DEFAULT="auto"
+# Icon style: "emoji" (default), "nerdfonts", "emoji_fixed", "auto"
+TMUX_POWERLINE_SEG_WEATHER_ICON_STYLE_DEFAULT="emoji"
 
-# Global cache file for weather data
 TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_WEATHER="${TMUX_POWERLINE_DIR_TEMPORARY}/weather_cache_data.txt"
-# Add: global cache file for auto-detected location (lat/lon)
 TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_LOCATION="${TMUX_POWERLINE_DIR_TEMPORARY}/weather_cache_location.txt"
-
 
 
 generate_segmentrc() {
@@ -34,6 +35,12 @@ export TMUX_POWERLINE_SEG_WEATHER_LOCATION_UPDATE_PERIOD="${TMUX_POWERLINE_SEG_W
 # Set both to "auto" to detect automatically based on your IP address, or set them manually
 export TMUX_POWERLINE_SEG_WEATHER_LAT="${TMUX_POWERLINE_SEG_WEATHER_LAT_DEFAULT}"
 export TMUX_POWERLINE_SEG_WEATHER_LON="${TMUX_POWERLINE_SEG_WEATHER_LON_DEFAULT}"
+# Icon style for weather condition symbols:
+#   "emoji"       - emoji with VS16 variation selector (default, original behaviour)
+#   "emoji_fixed" - emoji with VS16 stripped; use if tmux miscounts status-bar width
+#   "nerdfonts"   - Nerd Font PUA icons (1 cell, no width ambiguity)
+#   "auto"        - nerdfonts when a patched font is detected, else emoji
+export TMUX_POWERLINE_SEG_WEATHER_ICON_STYLE="${TMUX_POWERLINE_SEG_WEATHER_ICON_STYLE_DEFAULT}"
 EORC
 	echo "$rccontents"
 }
@@ -41,29 +48,60 @@ EORC
 
 run_segment() {
 	local weather=""
+	local update_period="${TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD:-$TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD_DEFAULT}"
 
-	# Check cache freshness and read if up-to-date
-	weather=$(__weather_cache_read)
+	# Always return cached data immediately (even stale), never block on network
+	if [ -f "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_WEATHER" ]; then
+		weather=$(__read_file_content "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_WEATHER")
+	fi
 
-	# Fetch from provider if empty
-	# If a new provider is implemented, please set the $weather variable!
-	if [ -z "$weather" ]; then
-		__process_settings
+	# If cache is stale or missing, trigger a background refresh
+	if ! __weather_cache_is_fresh "$update_period"; then
+		__weather_refresh_in_background
+	fi
+
+	echo "$weather"
+	return 0
+}
+
+
+# Returns 0 if cache is still fresh, 1 if stale or missing
+__weather_cache_is_fresh() {
+	local update_period="${1:-$TMUX_POWERLINE_SEG_WEATHER_UPDATE_PERIOD_DEFAULT}"
+	[ -f "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_WEATHER" ] || return 1
+	local last_update time_now
+	last_update=$(__read_file_last_update "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_WEATHER")
+	time_now=$(date +%s)
+	[ "$(echo "(${time_now}-${last_update}) < ${update_period}" | bc)" -eq 1 ]
+}
+
+
+# Spawn a background process to refresh the cache; does nothing if already running
+__weather_refresh_in_background() {
+	local lock_file="${TMUX_POWERLINE_DIR_TEMPORARY}/weather_refresh.lock"
+
+	# Bail out if a refresh is already in progress
+	[ -f "$lock_file" ] && return
+
+	(
+		trap 'rm -f "$lock_file"' EXIT
+		touch "$lock_file"
+
+		__process_settings || exit 1
+
+		local weather
 		case "$TMUX_POWERLINE_SEG_WEATHER_DATA_PROVIDER" in
 		"yrno")
 			weather=$(__yrno)
 			;;
 		*)
-			tp_err_seg "Err: Invalid weather data provider: ${TMUX_POWERLINE_SEG_WEATHER_DATA_PROVIDER}"
-			return 1
+			exit 1
 			;;
 		esac
 
-		# Cache weather data if we got something.
 		__weather_cache_write "$weather"
-	fi
-
-	echo "$weather"
+	) &
+	disown
 }
 
 
@@ -80,6 +118,9 @@ __process_settings() {
 	if [ -z "$TMUX_POWERLINE_SEG_WEATHER_LOCATION_UPDATE_PERIOD" ]; then
 		export TMUX_POWERLINE_SEG_WEATHER_LOCATION_UPDATE_PERIOD="${TMUX_POWERLINE_SEG_WEATHER_LOCATION_UPDATE_PERIOD_DEFAULT}"
 	fi
+	if [ -z "$TMUX_POWERLINE_SEG_WEATHER_ICON_STYLE" ]; then
+		export TMUX_POWERLINE_SEG_WEATHER_ICON_STYLE="${TMUX_POWERLINE_SEG_WEATHER_ICON_STYLE_DEFAULT}"
+	fi
 	if [ "$TMUX_POWERLINE_SEG_WEATHER_LAT" = "auto" ] || [ "$TMUX_POWERLINE_SEG_WEATHER_LON" = "auto" ] || [ -z "$TMUX_POWERLINE_SEG_WEATHER_LON" ] || [ -z "$TMUX_POWERLINE_SEG_WEATHER_LAT" ]; then
 		if ! __get_auto_location; then
 			exit 8
@@ -88,9 +129,7 @@ __process_settings() {
 }
 
 
-# An implementation of a weather provider, just need to echo the result, run_segment() will take care of the rest
 __yrno() {
-	# Ensure required tools exist
 	if ! command -v curl >/dev/null 2>&1; then
 		tp_err_seg "Err: curl not installed"
 		return 1
@@ -102,14 +141,11 @@ __yrno() {
 
 	local degree=""
 
-	# There's a chance that you will get rate limited or both location APIs are not working
-	# Then long and lat will be "null", as literal string
 	if [ -z "$TMUX_POWERLINE_SEG_WEATHER_LAT" ] || [ -z "$TMUX_POWERLINE_SEG_WEATHER_LON" ]; then
 		tp_err_seg "Err: Unable to auto-detect your location"
 		return 1
 	fi
 
-	# Ref: https://api.met.no/doc/TermsOfService
 	local user_agent
 	user_agent="tmux-powerline/$(tp_version) (https://github.com/erikw/tmux-powerline)"
 
@@ -134,80 +170,91 @@ __yrno() {
 	if [ "$TMUX_POWERLINE_SEG_WEATHER_UNIT" == "f" ]; then
 		degree=$(__degree_c2f "$degree")
 	fi
-	# condition_symbol=$(__get_yrno_condition_symbol "$condition" "$sunrise" "$sunset")
-	condition_symbol=$(__get_yrno_condition_symbol "$condition")
-	# Write the <content@date>, separated by a @ character, so we can fetch it later on without having to call 'stat'
+	local icon_style="${TMUX_POWERLINE_SEG_WEATHER_ICON_STYLE:-$TMUX_POWERLINE_SEG_WEATHER_ICON_STYLE_DEFAULT}"
+	if [ "$icon_style" = "auto" ]; then
+		tp_patched_font_in_use && icon_style="nerdfonts" || icon_style="emoji"
+	fi
+	local condition_symbol
+	condition_symbol=$(__get_yrno_condition_symbol "$condition" "$icon_style")
 	echo "${condition_symbol} ${degree}°$(echo "$TMUX_POWERLINE_SEG_WEATHER_UNIT" | tr '[:lower:]' '[:upper:]')"
 }
 
 
-# Convert from Celcius to Lord Kelvins.
 __degree_c2k() {
 	local c="$1"
 	echo "${c} + 273.15" | bc
 }
 
 
-# Convert from Celcius to Fahrenheits.
 __degree_c2f() {
 	local c="$1"
 	echo "${c} * 9 / 5 + 32" | bc
 }
 
 
-# Get symbol for condition. Available symbol names: https://api.met.no/weatherapi/weathericon/2.0/documentation#List_of_symbols
 __get_yrno_condition_symbol() {
-	# local condition=$(echo "$1" | tr '[:upper:]' '[:lower:]')
-	# local sunrise="$2"
-	# local sunset="$3"
-	local condition=$1
-	case "$condition" in
-	"clearsky_day")
-		echo "☀️ "
-		;;
-	"clearsky_night")
-		echo "🌙"
-		;;
-	"fair_day")
-		echo "🌤 "
-		;;
-	"fair_night")
-		echo "🌜"
-		;;
-	"fog")
-		echo "🌫 "
-		;;
-	"cloudy")
-		echo "☁️ "
-		;;
-	"rain" | "lightrain" | "heavyrain" | "sleet" | "lightsleet" | "heavysleet")
-		echo "🌧 "
-		;;
-	"heavyrainandthunder" | "heavyrainshowersandthunder_day" | "heavyrainshowersandthunder_night" | "heavysleetandthunder" | "heavysleetshowersandthunder_day" | "heavysnowandthunder" | "heavysnowshowersandthunder_day" | "heavysnowshowersandthunder_night" | "lightrainandthunder" | "lightrainshowersandthunder_day" | "lightrainshowersandthunder_night" | "lightsleetandthunder" | "lightsnowandthunder" | "lightssleetshowersandthunder_day" | "lightssleetshowersandthunder_night" | "lightssnowshowersandthunder_day" | "lightssnowshowersandthunder_night" | "rainandthunder" | "rainshowersandthunder_day" | "rainshowersandthunder_night" | "sleetandthunder" | "sleetshowersandthunder_day" | "sleetshowersandthunder_night" | "snowandthunder" | "snowshowersandthunder_day" | "snowshowersandthunder_night")
-		echo "⛈️ "
-		;;
-	"heavyrainshowers_day" | "heavysleetshowers_day" | "heavysleetshowersandthunder_night" | "lightrainshowers_day" | "lightsleetshowers_day" | "rainshowers_day" | "sleetshowers_day")
-		echo "🌦️ "
-		;;
-	"heavyrainshowers_night" | "heavysleetshowers_night" | "lightrainshowers_night" | "lightsleetshowers_night" | "rainshowers_night" | "sleetshowers_night")
-		echo "☔"
-		;;
-	"snow" | "lightsnow" | "heavysnow")
-		echo "❄️ "
-		;;
-	"lightsnowshowers_day" | "lightsnowshowers_night" | "heavysnowshowers_day" | "heavysnowshowers_night" | "snowshowers_day" | "snowshowers_night")
-		echo "🌨 "
-		;;
-	"partlycloudy_day")
-		echo "⛅"
-		;;
-	"partlycloudy_night")
-		echo "🌗"
-		;;
-	*)
-		echo "?"
-		;;
-	esac
+	local condition="$1"
+	local style="$2"
+
+	if [ "$style" = "nerdfonts" ]; then
+		# All Nerd Font icons are PUA (1 cell), no width ambiguity
+		case "$condition" in
+		"clearsky_day")           printf "\UF0599" ;;  # 󰖙 mdi-weather-sunny
+		"clearsky_night")         printf "\UF0594" ;;  # 󰖔 mdi-weather-night
+		"fair_day")               printf "\UF0595" ;;  # 󰖕 mdi-weather-partly-cloudy
+		"fair_night")             printf "\UF0F31" ;;  # 󰼱 mdi-weather-night-partly-cloudy
+		"fog")                    printf "\UF0591" ;;  # 󰖑 mdi-weather-fog
+		"cloudy")                 printf "\UF0590" ;;  # 󰖐 mdi-weather-cloudy
+		"rain" | "lightrain" | "heavyrain" | "sleet" | "lightsleet" | "heavysleet")
+			printf "\UF0597" ;;  # 󰖗 mdi-weather-rainy
+		"heavyrainandthunder" | "heavyrainshowersandthunder_day" | "heavyrainshowersandthunder_night" | "heavysleetandthunder" | "heavysleetshowersandthunder_day" | "heavysnowandthunder" | "heavysnowshowersandthunder_day" | "heavysnowshowersandthunder_night" | "lightrainandthunder" | "lightrainshowersandthunder_day" | "lightrainshowersandthunder_night" | "lightsleetandthunder" | "lightsnowandthunder" | "lightssleetshowersandthunder_day" | "lightssleetshowersandthunder_night" | "lightssnowshowersandthunder_day" | "lightssnowshowersandthunder_night" | "rainandthunder" | "rainshowersandthunder_day" | "rainshowersandthunder_night" | "sleetandthunder" | "sleetshowersandthunder_day" | "sleetshowersandthunder_night" | "snowandthunder" | "snowshowersandthunder_day" | "snowshowersandthunder_night")
+			printf "\UF067E" ;;  # 󰙾 mdi-weather-lightning-rainy
+		"heavyrainshowers_day" | "heavysleetshowers_day" | "heavysleetshowersandthunder_night" | "lightrainshowers_day" | "lightsleetshowers_day" | "rainshowers_day" | "sleetshowers_day")
+			printf "\UF0F33" ;;  # 󰼳 mdi-weather-partly-rainy
+		"heavyrainshowers_night" | "heavysleetshowers_night" | "lightrainshowers_night" | "lightsleetshowers_night" | "rainshowers_night" | "sleetshowers_night")
+			printf "\UF0597" ;;  # 󰖗 mdi-weather-rainy
+		"snow" | "lightsnow" | "heavysnow")
+			printf "\UF0598" ;;  # 󰖘 mdi-weather-snowy
+		"lightsnowshowers_day" | "lightsnowshowers_night" | "heavysnowshowers_day" | "heavysnowshowers_night" | "snowshowers_day" | "snowshowers_night")
+			printf "\UF0F34" ;;  # 󰼴 mdi-weather-partly-snowy
+		"partlycloudy_day")       printf "\UF0595" ;;  # 󰖕 mdi-weather-partly-cloudy
+		"partlycloudy_night")     printf "\UF0F31" ;;  # 󰼱 mdi-weather-night-partly-cloudy
+		*)                        echo "?" ;;
+		esac
+	else
+		# emoji / emoji_fixed: original symbols with VS16 variation selectors.
+		# "emoji_fixed" strips VS16 (U+FE0F) for terminals where Neutral-width base
+		# chars like ☀ (U+2600) + VS16 cause tmux to miscalculate status-bar width.
+		local symbol
+		case "$condition" in
+		"clearsky_day")           symbol="☀️ " ;;
+		"clearsky_night")         symbol="🌙" ;;
+		"fair_day")               symbol="🌤 " ;;
+		"fair_night")             symbol="🌜" ;;
+		"fog")                    symbol="🌫 " ;;
+		"cloudy")                 symbol="☁️ " ;;
+		"rain" | "lightrain" | "heavyrain" | "sleet" | "lightsleet" | "heavysleet")
+			symbol="🌧 " ;;
+		"heavyrainandthunder" | "heavyrainshowersandthunder_day" | "heavyrainshowersandthunder_night" | "heavysleetandthunder" | "heavysleetshowersandthunder_day" | "heavysnowandthunder" | "heavysnowshowersandthunder_day" | "heavysnowshowersandthunder_night" | "lightrainandthunder" | "lightrainshowersandthunder_day" | "lightrainshowersandthunder_night" | "lightsleetandthunder" | "lightsnowandthunder" | "lightssleetshowersandthunder_day" | "lightssleetshowersandthunder_night" | "lightssnowshowersandthunder_day" | "lightssnowshowersandthunder_night" | "rainandthunder" | "rainshowersandthunder_day" | "rainshowersandthunder_night" | "sleetandthunder" | "sleetshowersandthunder_day" | "sleetshowersandthunder_night" | "snowandthunder" | "snowshowersandthunder_day" | "snowshowersandthunder_night")
+			symbol="⛈️ " ;;
+		"heavyrainshowers_day" | "heavysleetshowers_day" | "heavysleetshowersandthunder_night" | "lightrainshowers_day" | "lightsleetshowers_day" | "rainshowers_day" | "sleetshowers_day")
+			symbol="🌦️ " ;;
+		"heavyrainshowers_night" | "heavysleetshowers_night" | "lightrainshowers_night" | "lightsleetshowers_night" | "rainshowers_night" | "sleetshowers_night")
+			symbol="☔" ;;
+		"snow" | "lightsnow" | "heavysnow")
+			symbol="❄️ " ;;
+		"lightsnowshowers_day" | "lightsnowshowers_night" | "heavysnowshowers_day" | "heavysnowshowers_night" | "snowshowers_day" | "snowshowers_night")
+			symbol="🌨 " ;;
+		"partlycloudy_day")       symbol="⛅" ;;
+		"partlycloudy_night")     symbol="🌗" ;;
+		*)                        symbol="?" ;;
+		esac
+		if [ "$style" = "emoji_fixed" ]; then
+			printf '%s' "$symbol" | sed 's/\xef\xb8\x8f//g'
+		else
+			printf '%s' "$symbol"
+		fi
+	fi
 }
 
 
@@ -229,19 +276,16 @@ __read_file_split() {
 }
 
 
-# Default to empty/blank
 __read_file_content() {
 	__read_file_split "$1" 0 ""
 }
 
 
-# Default to 0
 __read_file_last_update() {
 	__read_file_split "$1" 1 0
 }
 
 
-# Read cached content if still fresh; otherwise output empty
 __weather_cache_read() {
 	local last_update time_now up_to_date
 	if [ ! -f "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_WEATHER" ]; then
@@ -259,7 +303,6 @@ __weather_cache_read() {
 }
 
 
-# Write <content@timestamp> to a file, overwriting existing content
 __write_to_file_with_last_updated() {
 	local file_to_write="$1"
 	local content="$2"
@@ -270,76 +313,70 @@ __write_to_file_with_last_updated() {
 }
 
 
-# Weather-specific cache write: only write when content is non-empty
 __weather_cache_write() {
 	local content="$1"
 	if [ -n "$content" ]; then
 		__write_to_file_with_last_updated "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_WEATHER" "$content"
 	else
-		# Overwrite the cache file with an error message and updated timestamp to avoid repeated fetch attempts while the provider is unavailable
 		tp_err_seg "Err: Failed to fetch weather data, caching error message to avoid repeated fetch attempts"
 		__write_to_file_with_last_updated "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_WEATHER" "failed to fetch weather data"
 	fi
 }
 
 
-# Try setting TMUX_POWERLINE_SEG_WEATHER_LAT & TMUX_POWERLINE_SEG_WEATHER_LON automatically with GeoIP services.
 __get_auto_location() {
-    local max_cache_age=$TMUX_POWERLINE_SEG_WEATHER_LOCATION_UPDATE_PERIOD
-    local -a lat_lon_arr
+	local max_cache_age=$TMUX_POWERLINE_SEG_WEATHER_LOCATION_UPDATE_PERIOD
+	local -a lat_lon_arr
 
-    if [[ -f "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_LOCATION" ]]; then
-        local cache_age=$(($(date +%s) - $(__read_file_last_update "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_LOCATION")))
-        if (( cache_age < max_cache_age )); then
-            IFS=' ' read -ra lat_lon_arr <<< "$(__read_file_content "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_LOCATION")"
-            TMUX_POWERLINE_SEG_WEATHER_LAT=${lat_lon_arr[0]}
-            TMUX_POWERLINE_SEG_WEATHER_LON=${lat_lon_arr[1]}
-            if [[ -n "$TMUX_POWERLINE_SEG_WEATHER_LAT" && -n "$TMUX_POWERLINE_SEG_WEATHER_LON" ]]; then
-                return 0
-            fi
-        fi
-    fi
+	if [[ -f "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_LOCATION" ]]; then
+		local cache_age=$(($(date +%s) - $(__read_file_last_update "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_LOCATION")))
+		if (( cache_age < max_cache_age )); then
+			IFS=' ' read -ra lat_lon_arr <<< "$(__read_file_content "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_LOCATION")"
+			TMUX_POWERLINE_SEG_WEATHER_LAT=${lat_lon_arr[0]}
+			TMUX_POWERLINE_SEG_WEATHER_LON=${lat_lon_arr[1]}
+			if [[ -n "$TMUX_POWERLINE_SEG_WEATHER_LAT" && -n "$TMUX_POWERLINE_SEG_WEATHER_LON" ]]; then
+				return 0
+			fi
+		fi
+	fi
 
-    local location_data
-    for api in "https://ipapi.co/json" "https://ipinfo.io/json"; do
-        if location_data=$(curl --max-time 4 -s "$api"); then
-            case "$api" in
-                *ipapi.co*)
-                    TMUX_POWERLINE_SEG_WEATHER_LAT=$(echo "$location_data" | jq -r '.latitude')
-                    TMUX_POWERLINE_SEG_WEATHER_LON=$(echo "$location_data" | jq -r '.longitude')
-                    ;;
-                *ipinfo.io*)
-                    IFS=',' read -ra loc <<< "$(echo "$location_data" | jq -r '.loc')"
-                    TMUX_POWERLINE_SEG_WEATHER_LAT="${loc[0]}"
-                    TMUX_POWERLINE_SEG_WEATHER_LON="${loc[1]}"
-                    ;;
-            esac
+	local location_data
+	for api in "https://ipapi.co/json" "https://ipinfo.io/json"; do
+		if location_data=$(curl --max-time 4 -s "$api"); then
+			case "$api" in
+				*ipapi.co*)
+					TMUX_POWERLINE_SEG_WEATHER_LAT=$(echo "$location_data" | jq -r '.latitude')
+					TMUX_POWERLINE_SEG_WEATHER_LON=$(echo "$location_data" | jq -r '.longitude')
+					;;
+				*ipinfo.io*)
+					IFS=',' read -ra loc <<< "$(echo "$location_data" | jq -r '.loc')"
+					TMUX_POWERLINE_SEG_WEATHER_LAT="${loc[0]}"
+					TMUX_POWERLINE_SEG_WEATHER_LON="${loc[1]}"
+					;;
+			esac
 
-            # There's no data, move on to the next API, just don't overwrite the previous location
-            # Also, there's a case where lat/lon was set to "null" as a string, gotta handle it
-            if [[ -z "$TMUX_POWERLINE_SEG_WEATHER_LAT" ||
-                  -z "$TMUX_POWERLINE_SEG_WEATHER_LON" ||
-                  "$TMUX_POWERLINE_SEG_WEATHER_LAT" == "null" ||
-                  "$TMUX_POWERLINE_SEG_WEATHER_LON" == "null" ]]; then
-                continue
-            fi
+			if [[ -z "$TMUX_POWERLINE_SEG_WEATHER_LAT" ||
+			      -z "$TMUX_POWERLINE_SEG_WEATHER_LON" ||
+			      "$TMUX_POWERLINE_SEG_WEATHER_LAT" == "null" ||
+			      "$TMUX_POWERLINE_SEG_WEATHER_LON" == "null" ]]; then
+				continue
+			fi
 
-            # Write location using helper to append timestamp
-            __write_to_file_with_last_updated "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_LOCATION" "$TMUX_POWERLINE_SEG_WEATHER_LAT $TMUX_POWERLINE_SEG_WEATHER_LON"
-            return 0
-        fi
-    done
+			__write_to_file_with_last_updated "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_LOCATION" "$TMUX_POWERLINE_SEG_WEATHER_LAT $TMUX_POWERLINE_SEG_WEATHER_LON"
+			return 0
+		fi
+	done
 
-    if [[ -f "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_LOCATION" ]]; then
-        tp_err_seg "Warn: Using stale location data (failed to refresh)"
-        IFS=' ' read -ra lat_lon_arr <<< "$(__read_file_content "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_LOCATION")"
-        TMUX_POWERLINE_SEG_WEATHER_LAT=${lat_lon_arr[0]}
-        TMUX_POWERLINE_SEG_WEATHER_LON=${lat_lon_arr[1]}
-        if [[ -n "$TMUX_POWERLINE_SEG_WEATHER_LAT" && -n "$TMUX_POWERLINE_SEG_WEATHER_LON" ]]; then
-            return 0
-        fi
-    fi
+	if [[ -f "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_LOCATION" ]]; then
+		tp_err_seg "Warn: Using stale location data (failed to refresh)"
+		IFS=' ' read -ra lat_lon_arr <<< "$(__read_file_content "$TMUX_POWERLINE_SEG_WEATHER_CACHE_FILE_LOCATION")"
+		TMUX_POWERLINE_SEG_WEATHER_LAT=${lat_lon_arr[0]}
+		TMUX_POWERLINE_SEG_WEATHER_LON=${lat_lon_arr[1]}
+		if [[ -n "$TMUX_POWERLINE_SEG_WEATHER_LAT" && -n "$TMUX_POWERLINE_SEG_WEATHER_LON" ]]; then
+			return 0
+		fi
+	fi
 
-    tp_err_seg "Err: Could not detect location automatically"
-    return 1
+	tp_err_seg "Err: Could not detect location automatically"
+	return 1
 }


### PR DESCRIPTION
## Problem

`weather.sh` and `wan_ip.sh` perform synchronous `curl` calls whenever their cache expires. During this window, `powerline.sh` blocks for up to **12 seconds** (weather: location API × 2 + forecast API) or **2 seconds** (wan_ip), causing tmux to display a `<'powerline.sh ...' not ready>` placeholder and the status bar to visually push terminal content upward.

This has been reported in:
- #351 — Screen scrolling & status bar duplication
- #266 — weather segment causes status bar to update continuously

The issue is intermittent because it only triggers when the cache expires (every 10 min for weather, every 15 min for wan_ip), making it hard to trace back to the segments.

## Root Cause

Both segments used the pattern:
```
cache fresh → return immediately
cache stale → synchronous curl → update cache → return
```

The stale branch blocks the entire `powerline.sh` process, preventing tmux from rendering the status bar in time.

A secondary issue in `weather.sh`: condition symbols using VS16 variation selectors (e.g. `☀️` = U+2600 + U+FE0F) cause tmux to miscount the status-bar width. The base character (U+2600) has East Asian Width: Neutral (1 cell), but VS16 makes the terminal render it as 2 cells. The 1-cell discrepancy causes the status bar to overflow and wrap, pushing terminal content up. This only triggers for specific weather conditions (clearsky, cloudy, thunderstorm, snow) which explains why the symptom appears intermittently.

## Fix

### Non-blocking fetch (both segments)

The cache is now the sole data source for `run_segment()`. It always returns immediately — even stale data is better than blocking:

```
always return cached value (even if stale)
cache stale or missing → spawn background subshell to refresh
```

A lock file prevents concurrent background refreshes. On first run with no cache, the segment displays empty until the background fetch completes (a few seconds).

### Weather icon style option (`weather.sh` only)

Adds `TMUX_POWERLINE_SEG_WEATHER_ICON_STYLE` to let users opt in to width-safe icon rendering. The default preserves the original behaviour so no existing setup is affected:

| Value | Behaviour |
|---|---|
| `emoji` | Original emoji with VS16 preserved **(default)** |
| `emoji_fixed` | VS16 stripped — for terminals where tmux miscounts width |
| `nerdfonts` | Nerd Font PUA icons (fixed 1-cell width, no ambiguity) |
| `auto` | `nerdfonts` if `tp_patched_font_in_use()`, else `emoji` |

## Testing

Tested on Linux (Ghostty terminal, tmux 3.x) over several days. Verified:
- Status bar no longer pushes up during cache refresh cycles
- `time bash powerline.sh right` returns in ~0.15s regardless of cache state
- All four icon styles render correctly